### PR TITLE
chore: release v0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.17](https://github.com/Boshen/cargo-shear/compare/v0.0.16...v0.0.17) - 2024-04-01
+
+### Fixed
+- ignored packages by package name instead of normalized name
+
+### Other
+- fix broken ci
+- make `shear_package` the more readable
+- minor tweak
+- add `--no-deps` to `cargo metadata`
+- add `just ready`
+- run shear on this repo
+
 ## [0.0.16](https://github.com/Boshen/cargo-shear/compare/v0.0.15...v0.0.16) - 2024-03-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "0.0.16"
+version = "0.0.17"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 0.0.16 -> 0.0.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.17](https://github.com/Boshen/cargo-shear/compare/v0.0.16...v0.0.17) - 2024-04-01

### Fixed
- ignored packages by package name instead of normalized name

### Other
- fix broken ci
- make `shear_package` the more readable
- minor tweak
- add `--no-deps` to `cargo metadata`
- add `just ready`
- run shear on this repo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).