### PR TITLE
chore: release v0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.21](https://github.com/Boshen/cargo-shear/compare/v0.0.20...v0.0.21) - 2024-04-03
+
+### Other
+- fix github.ref read
+
 ## [0.0.20](https://github.com/Boshen/cargo-shear/compare/v0.0.19...v0.0.20) - 2024-04-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "0.0.20"
+version = "0.0.21"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 0.0.20 -> 0.0.21 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.21](https://github.com/Boshen/cargo-shear/compare/v0.0.20...v0.0.21) - 2024-04-03

### Other
- fix github.ref read
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).