### PR TITLE
chore: release v0.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.23](https://github.com/Boshen/cargo-shear/compare/v0.0.22...v0.0.23) - 2024-04-03
+
+### Fixed
+- collect import from all use declarations
+
+### Other
+- use [lints.clippy]
+
 ## [0.0.22](https://github.com/Boshen/cargo-shear/compare/v0.0.21...v0.0.22) - 2024-04-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 0.0.22 -> 0.0.23 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.23](https://github.com/Boshen/cargo-shear/compare/v0.0.22...v0.0.23) - 2024-04-03

### Fixed
- collect import from all use declarations

### Other
- use [lints.clippy]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).