### PR TITLE
chore: release v0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.26](https://github.com/Boshen/cargo-shear/compare/v0.0.25...v0.0.26) - 2024-05-29
+
+### Added
+- exit code is 0 when performing fix ([#52](https://github.com/Boshen/cargo-shear/pull/52))
+
+### Other
+- *(deps)* lock file maintenance rust crates ([#49](https://github.com/Boshen/cargo-shear/pull/49))
+- update README
+- update README
+- link prior arts
+- document prior arts
+- allow branch `renovate/**`
+- *(deps)* lock file maintenance rust crates ([#46](https://github.com/Boshen/cargo-shear/pull/46))
+- *(deps)* lock file maintenance rust crates ([#44](https://github.com/Boshen/cargo-shear/pull/44))
+- add PR from astral-sh/uv
+- *(deps)* lock file maintenance rust crates ([#43](https://github.com/Boshen/cargo-shear/pull/43))
+- use shared renovate config
+
 ## [0.0.25](https://github.com/Boshen/cargo-shear/compare/v0.0.24...v0.0.25) - 2024-05-02
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - exit code is 0 when performing fix ([#52](https://github.com/Boshen/cargo-shear/pull/52))
 
-### Other
-- *(deps)* lock file maintenance rust crates ([#49](https://github.com/Boshen/cargo-shear/pull/49))
-- update README
-- update README
-- link prior arts
-- document prior arts
-- allow branch `renovate/**`
-- *(deps)* lock file maintenance rust crates ([#46](https://github.com/Boshen/cargo-shear/pull/46))
-- *(deps)* lock file maintenance rust crates ([#44](https://github.com/Boshen/cargo-shear/pull/44))
-- add PR from astral-sh/uv
-- *(deps)* lock file maintenance rust crates ([#43](https://github.com/Boshen/cargo-shear/pull/43))
-- use shared renovate config
-
 ## [0.0.25](https://github.com/Boshen/cargo-shear/compare/v0.0.24...v0.0.25) - 2024-05-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "0.0.25"
+version = "0.0.26"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 0.0.25 -> 0.0.26

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.26](https://github.com/Boshen/cargo-shear/compare/v0.0.25...v0.0.26) - 2024-05-29

### Added
- exit code is 0 when performing fix ([#52](https://github.com/Boshen/cargo-shear/pull/52))

### Other
- *(deps)* lock file maintenance rust crates ([#49](https://github.com/Boshen/cargo-shear/pull/49))
- update README
- update README
- link prior arts
- document prior arts
- allow branch `renovate/**`
- *(deps)* lock file maintenance rust crates ([#46](https://github.com/Boshen/cargo-shear/pull/46))
- *(deps)* lock file maintenance rust crates ([#44](https://github.com/Boshen/cargo-shear/pull/44))
- add PR from astral-sh/uv
- *(deps)* lock file maintenance rust crates ([#43](https://github.com/Boshen/cargo-shear/pull/43))
- use shared renovate config
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).