### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3](https://github.com/Boshen/cargo-shear/compare/v1.1.2...v1.1.3) - 2024-08-29
+
+### Other
+- Add trophy cases for reqsign ([#80](https://github.com/Boshen/cargo-shear/pull/80))
+- *(deps)* update rust crates ([#79](https://github.com/Boshen/cargo-shear/pull/79))
+- *(README)* mention rustc and clippy
+
 ## [1.1.2](https://github.com/Boshen/cargo-shear/compare/v1.1.1...v1.1.2) - 2024-08-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 1.1.2 -> 1.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.3](https://github.com/Boshen/cargo-shear/compare/v1.1.2...v1.1.3) - 2024-08-29

### Other
- Add trophy cases for reqsign ([#80](https://github.com/Boshen/cargo-shear/pull/80))
- *(deps)* update rust crates ([#79](https://github.com/Boshen/cargo-shear/pull/79))
- *(README)* mention rustc and clippy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).