### PR TITLE
chore: release v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4](https://github.com/Boshen/cargo-shear/compare/v1.1.3...v1.1.4) - 2024-11-25
+
+### Other
+
+- *(deps)* update rust crates ([#99](https://github.com/Boshen/cargo-shear/pull/99))
+- *(deps)* update rust crate serde_json to 1.0.133 ([#98](https://github.com/Boshen/cargo-shear/pull/98))
+- *(deps)* update rust crate anyhow to 1.0.93 ([#97](https://github.com/Boshen/cargo-shear/pull/97))
+- *(deps)* update rust crates ([#96](https://github.com/Boshen/cargo-shear/pull/96))
+- *(deps)* update rust crates ([#94](https://github.com/Boshen/cargo-shear/pull/94))
+- *(deps)* update rust crates ([#92](https://github.com/Boshen/cargo-shear/pull/92))
+- *(deps)* update dependency rust to v1.82.0 ([#91](https://github.com/Boshen/cargo-shear/pull/91))
+- *(deps)* update rust crates ([#90](https://github.com/Boshen/cargo-shear/pull/90))
+- *(deps)* update rust crates ([#88](https://github.com/Boshen/cargo-shear/pull/88))
+
 ## [1.1.3](https://github.com/Boshen/cargo-shear/compare/v1.1.2...v1.1.3) - 2024-09-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 1.1.3 -> 1.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.4](https://github.com/Boshen/cargo-shear/compare/v1.1.3...v1.1.4) - 2024-11-25

### Other

- *(deps)* update rust crates ([#99](https://github.com/Boshen/cargo-shear/pull/99))
- *(deps)* update rust crate serde_json to 1.0.133 ([#98](https://github.com/Boshen/cargo-shear/pull/98))
- *(deps)* update rust crate anyhow to 1.0.93 ([#97](https://github.com/Boshen/cargo-shear/pull/97))
- *(deps)* update rust crates ([#96](https://github.com/Boshen/cargo-shear/pull/96))
- *(deps)* update rust crates ([#94](https://github.com/Boshen/cargo-shear/pull/94))
- *(deps)* update rust crates ([#92](https://github.com/Boshen/cargo-shear/pull/92))
- *(deps)* update dependency rust to v1.82.0 ([#91](https://github.com/Boshen/cargo-shear/pull/91))
- *(deps)* update rust crates ([#90](https://github.com/Boshen/cargo-shear/pull/90))
- *(deps)* update rust crates ([#88](https://github.com/Boshen/cargo-shear/pull/88))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).