### PR TITLE
chore: release v1.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.7](https://github.com/Boshen/cargo-shear/compare/v1.1.6...v1.1.7) - 2025-01-10
+
+### Other
+
+- update rustfmt
+
 ## [1.1.6](https://github.com/Boshen/cargo-shear/compare/v1.1.5...v1.1.6) - 2025-01-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.6"
+version = "1.1.7"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION
## 🤖 New release
* `cargo-shear`: 1.1.6 -> 1.1.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.7](https://github.com/Boshen/cargo-shear/compare/v1.1.6...v1.1.7) - 2025-01-10

### Other

- update rustfmt
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).