### PR TITLE
chore: release v1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9](https://github.com/Boshen/cargo-shear/compare/v1.1.8...v1.1.9) - 2025-02-11
+
+### Other
+
+- *(deps)* lock file maintenance rust crates (#118)
+- Update README.md
+- *(deps)* update rust crates (#116)
+- *(deps)* update dependency rust to v1.84.1 (#115)
+- *(deps)* update rust crate bpaf to 0.9.16 (#114)
+- *(deps)* update rust crate serde_json to 1.0.137 (#113)
+- *(deps)* update rust crate serde_json to 1.0.136 (#112)
+- *(deps)* update rust crates (#110)
+
 ## [1.1.8](https://github.com/Boshen/cargo-shear/compare/v1.1.7...v1.1.8) - 2025-01-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.8"
+version = "1.1.9"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.8"
+version = "1.1.9"
 edition = "2021"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.1.8 -> 1.1.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.9](https://github.com/Boshen/cargo-shear/compare/v1.1.8...v1.1.9) - 2025-02-11

### Other

- *(deps)* lock file maintenance rust crates (#118)
- Update README.md
- *(deps)* update rust crates (#116)
- *(deps)* update dependency rust to v1.84.1 (#115)
- *(deps)* update rust crate bpaf to 0.9.16 (#114)
- *(deps)* update rust crate serde_json to 1.0.137 (#113)
- *(deps)* update rust crate serde_json to 1.0.136 (#112)
- *(deps)* update rust crates (#110)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).