### PR TITLE
chore: release v1.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.10](https://github.com/Boshen/cargo-shear/compare/v1.1.9...v1.1.10) - 2025-02-21
+
+### Other
+
+- Rust 2024
+- *(deps)* update dependency rust to v1.85.0 (#126)
+- *(deps)* update taiki-e/install-action action to v2.48.15 (#125)
+- *(deps)* update taiki-e/install-action action to v2.48.14 (#124)
+- *(deps)* update github-actions (#123)
+- use oxc-project/setup-rust
+- pinGitHubActionDigestsToSemver
+
 ## [1.1.9](https://github.com/Boshen/cargo-shear/compare/v1.1.8...v1.1.9) - 2025-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.9"
+version = "1.1.10"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.1.9 -> 1.1.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.10](https://github.com/Boshen/cargo-shear/compare/v1.1.9...v1.1.10) - 2025-02-21

### Other

- Rust 2024
- *(deps)* update dependency rust to v1.85.0 (#126)
- *(deps)* update taiki-e/install-action action to v2.48.15 (#125)
- *(deps)* update taiki-e/install-action action to v2.48.14 (#124)
- *(deps)* update github-actions (#123)
- use oxc-project/setup-rust
- pinGitHubActionDigestsToSemver
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).