### PR TITLE
chore: release v1.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.11](https://github.com/Boshen/cargo-shear/compare/v1.1.10...v1.1.11) - 2025-03-17
+
+### Other
+
+- trigger CI when workflow file changes
+- *(deps)* lock file maintenance rust crates ([#138](https://github.com/Boshen/cargo-shear/pull/138))
+- *(deps)* update github-actions ([#135](https://github.com/Boshen/cargo-shear/pull/135))
+- *(deps)* lock file maintenance rust crates ([#136](https://github.com/Boshen/cargo-shear/pull/136))
+- *(deps)* update github-actions ([#131](https://github.com/Boshen/cargo-shear/pull/131))
+- *(deps)* lock file maintenance rust crates ([#132](https://github.com/Boshen/cargo-shear/pull/132))
+- improve tests & add more lints ([#130](https://github.com/Boshen/cargo-shear/pull/130))
+- *(deps)* update github-actions ([#127](https://github.com/Boshen/cargo-shear/pull/127))
+- update trigger
+
 ## [1.1.10](https://github.com/Boshen/cargo-shear/compare/v1.1.9...v1.1.10) - 2025-02-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.10"
+version = "1.1.11"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.10"
+version = "1.1.11"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.1.10 -> 1.1.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.11](https://github.com/Boshen/cargo-shear/compare/v1.1.10...v1.1.11) - 2025-03-17

### Other

- trigger CI when workflow file changes
- *(deps)* lock file maintenance rust crates ([#138](https://github.com/Boshen/cargo-shear/pull/138))
- *(deps)* update github-actions ([#135](https://github.com/Boshen/cargo-shear/pull/135))
- *(deps)* lock file maintenance rust crates ([#136](https://github.com/Boshen/cargo-shear/pull/136))
- *(deps)* update github-actions ([#131](https://github.com/Boshen/cargo-shear/pull/131))
- *(deps)* lock file maintenance rust crates ([#132](https://github.com/Boshen/cargo-shear/pull/132))
- improve tests & add more lints ([#130](https://github.com/Boshen/cargo-shear/pull/130))
- *(deps)* update github-actions ([#127](https://github.com/Boshen/cargo-shear/pull/127))
- update trigger
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).