### PR TITLE
chore: release v1.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.12](https://github.com/Boshen/cargo-shear/compare/v1.1.11...v1.1.12) - 2025-04-04
+
+### Other
+
+- use regex-lite
+- `cargo upgrade -i`
+- *(deps)* update dependency rust to v1.86.0 ([#146](https://github.com/Boshen/cargo-shear/pull/146))
+- *(deps)* update github-actions ([#144](https://github.com/Boshen/cargo-shear/pull/144))
+- *(deps)* lock file maintenance ([#145](https://github.com/Boshen/cargo-shear/pull/145))
+- *(deps)* update github-actions ([#142](https://github.com/Boshen/cargo-shear/pull/142))
+- *(deps)* update dependency rust to v1.85.1 ([#140](https://github.com/Boshen/cargo-shear/pull/140))
+
 ## [1.1.11](https://github.com/Boshen/cargo-shear/compare/v1.1.10...v1.1.11) - 2025-03-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.11"
+version = "1.1.12"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.11"
+version = "1.1.12"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.1.11 -> 1.1.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.12](https://github.com/Boshen/cargo-shear/compare/v1.1.11...v1.1.12) - 2025-04-04

### Other

- use regex-lite
- `cargo upgrade -i`
- *(deps)* update dependency rust to v1.86.0 ([#146](https://github.com/Boshen/cargo-shear/pull/146))
- *(deps)* update github-actions ([#144](https://github.com/Boshen/cargo-shear/pull/144))
- *(deps)* lock file maintenance ([#145](https://github.com/Boshen/cargo-shear/pull/145))
- *(deps)* update github-actions ([#142](https://github.com/Boshen/cargo-shear/pull/142))
- *(deps)* update dependency rust to v1.85.1 ([#140](https://github.com/Boshen/cargo-shear/pull/140))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).