### PR TITLE
chore: release v1.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.14](https://github.com/Boshen/cargo-shear/compare/v1.1.13...v1.1.14) - 2025-04-16
+
+### Other
+
+- build on ubuntu-latest. ubuntu-20.04 is retired ([#153](https://github.com/Boshen/cargo-shear/pull/153))
+
 ## [1.1.13](https://github.com/Boshen/cargo-shear/compare/v1.1.12...v1.1.13) - 2025-04-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.1.13"
+version = "1.1.14"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.1.13 -> 1.1.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.14](https://github.com/Boshen/cargo-shear/compare/v1.1.13...v1.1.14) - 2025-04-16

### Other

- build on ubuntu-latest. ubuntu-20.04 is retired ([#153](https://github.com/Boshen/cargo-shear/pull/153))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).