### PR TITLE
feat: `--fix` remove unused dependencies from [features] section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,7 @@ impl CargoShear {
         Ok(imports)
     }
 
+    #[expect(clippy::option_if_let_else, reason = "Current code is more readable.")]
     fn try_fix_package(
         &mut self,
         cargo_toml_path: &Path,


### PR DESCRIPTION
As I left in the comment, it's a bit more complicated to fix features.

ex. let's say we're removing `bytes`:
```toml
[features]
# Is this extending the implicit "bytes" feature, or making a new explicit feature?
# if implicit: then remove it since the dependency no longer exists?
# if explicit: don't touch it.
bytes = []

# This case is easy, remove `dep:bytes`
explicit = ["dep:bytes"]

# This case is a bit harder. 
# If an explicit `bytes` feature exists, then don't remove it.
# If `dep:bytes` exists anywhere, then don't remove it either? Or is this illegal already?
# Otherwise remove the dependency.
implicit = ["bytes"]
```