### PR TITLE
Add `--expand` to expand macros to find any hidden dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ cargo shear --fix
 > [!IMPORTANT]
 > `cargo shear` cannot detect "hidden" imports from macro expansions without the `--expand` flag (nightly only).
 > This is because `cargo shear` uses `syn` to parse files and does not expand macros by default.
-> The `--expand` flag uses `cargo expand` to expand macros instead, which is significantly slower and requires nightly.
+
+To expand macros:
+
+```bash
+cargo shear --expand --fix
+```
+
+The `--expand` flag uses `cargo expand`, which requires nightly and is significantly slower.
 
 ## Ignore false positives
 
@@ -66,7 +73,7 @@ The exit code gives an indication whether unused dependencies have been found:
 1. use the `cargo_metadata` crate to list all dependencies specified in `[workspace.dependencies]` and `[dependencies]`
 2. iterate through all package targets (`lib`, `bin`, `example`, `test` and `bench`) to locate all Rust files
 3. use `syn` to parse these Rust files and extract imports
-  - or use `cargo expand` to expand macros and then parse the expanded code
+  - alternatively, use the `--expand` option with `cargo expand` to first expand macros and then parse the expanded code (though this is significantly slower).
 4. find the difference between the imports and the package dependencies
 
 ## Prior Arts

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ cargo shear --fix
 ## Limitation
 
 > [!IMPORTANT]
-> `cargo shear` cannot detect "hidden" imports from macro expansions.
-> This is because `cargo shear` uses `syn` to parse files and does not expand macros.
+> `cargo shear` cannot detect "hidden" imports from macro expansions without the `--expand` flag (nightly only).
+> This is because `cargo shear` uses `syn` to parse files and does not expand macros by default.
+> The `--expand` flag uses `cargo expand` to expand macros instead, which is significantly slower and requires nightly.
 
 ## Ignore false positives
 
@@ -65,6 +66,7 @@ The exit code gives an indication whether unused dependencies have been found:
 1. use the `cargo_metadata` crate to list all dependencies specified in `[workspace.dependencies]` and `[dependencies]`
 2. iterate through all package targets (`lib`, `bin`, `example`, `test` and `bench`) to locate all Rust files
 3. use `syn` to parse these Rust files and extract imports
+  - or use `cargo expand` to expand macros and then parse the expanded code
 4. find the difference between the imports and the package dependencies
 
 ## Prior Arts

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -81,6 +81,7 @@ fn test_lib() {
         package: vec![],
         exclude: vec![],
         path: default_path().unwrap(),
+        expand: false,
     });
     let exit_code = shear.run();
     assert_eq!(exit_code, ExitCode::SUCCESS);


### PR DESCRIPTION
nightly only

Based on cargo expand, but not as sophisticated. This is muuuuch slower because it has to compile every target so I'm not sure if it's practical, but super neat. Running it on the mono-workspace at work and it works pretty well.