### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1](https://github.com/Boshen/cargo-shear/compare/v1.2.0...v1.2.1) - 2025-04-20
+
+### Other
+
+- Use mimalloc on pre-built binaries. 1.2x times faster! ([#162](https://github.com/Boshen/cargo-shear/pull/162))
+- Add `--expand` to expand macros to find any hidden dependencies ([#159](https://github.com/Boshen/cargo-shear/pull/159))
+
 ## [1.2.0](https://github.com/Boshen/cargo-shear/compare/v1.1.14...v1.2.0) - 2025-04-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.2.0 -> 1.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.1](https://github.com/Boshen/cargo-shear/compare/v1.2.0...v1.2.1) - 2025-04-20

### Other

- Use mimalloc on pre-built binaries. 1.2x times faster! ([#162](https://github.com/Boshen/cargo-shear/pull/162))
- Add `--expand` to expand macros to find any hidden dependencies ([#159](https://github.com/Boshen/cargo-shear/pull/159))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).