### PR TITLE
README.md: Document how to install cargo-shear using homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Detect and remove unused dependencies from `Cargo.toml` in Rust projects.
 ```bash
 cargo binstall cargo-shear
 # OR
+brew install cargo-shear
+
+# Build from source
 cargo install cargo-shear
 ```
 


### PR DESCRIPTION
~~cargo-shear hasn’t been merged into homebrew-core yet, but since there are no particular issues and it follows Homebrew’s [acceptable formulae guidelines](https://docs.brew.sh/Acceptable-Formulae), it will likely be accepted.~~

~~Assuming it will be merged, I’ve gone ahead and created a PR that updates the README in advance. Please take a look and see if the format aligns with your preferences.~~

~~Once the formula is merged, I’ll mark this PR as ready for review.~~

It's merged

```bash
brew install cargo-shear
```

###### Reference
- https://github.com/Homebrew/homebrew-core/pull/220832