### PR TITLE
Revert "perf: Use mimalloc on pre-built binaries. "

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -51,12 +51,9 @@ jobs:
         if: contains(matrix.target, '-linux-musl')
 
       - uses: taiki-e/upload-rust-binary-action@e7953b6078194a4ae5f5619632e3715db6275561 # v1.24.0
-        env:
-          CC: clang # for mimalloc
         with:
           bin: cargo-shear
           target: ${{ matrix.target }}
           tar: all
           zip: windows
-          features: allocator
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "cargo-util-schemas",
  "cargo_metadata",
  "cargo_toml",
- "mimalloc-safe",
  "proc-macro2",
  "rayon",
  "regex-lite",
@@ -109,24 +108,6 @@ checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
 dependencies = [
  "serde",
  "toml",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
-dependencies = [
- "shlex",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -358,22 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "libc"
-version = "0.2.172"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libmimalloc-sys2"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584d72b26f578b3084461aa713f17237fc93d9a467844dd4df4a98d6fbbb6db0"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,15 +349,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mimalloc-safe"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062d14d92efc78427be0f955459ac69c1e687e868784a7f55d27115c66cf739c"
-dependencies = [
- "libmimalloc-sys2",
-]
 
 [[package]]
 name = "num-traits"
@@ -547,12 +503,6 @@ checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,21 +36,6 @@ anyhow = "1.0.97"
 cargo-util-schemas = "0.8.0"
 serde_json = "1.0.140"
 
-[target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_family = "wasm")))'.dependencies]
-mimalloc-safe = { version = "0.1.50", optional = true, features = [
-  "skip_collect_on_exit",
-] }
-
-[target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
-mimalloc-safe = { version = "0.1.50", optional = true, features = [
-  "skip_collect_on_exit",
-  "local_dynamic_tls",
-] }
-
-[features]
-default = []
-allocator = ["dep:mimalloc-safe"]
-
 [profile.release]
 # Configurations explicitly listed here for clarity.
 # Using the best options for performance.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-#[cfg(feature = "allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
-
 use std::process::ExitCode;
 
 use cargo_shear::{CargoShear, cargo_shear_options};


### PR DESCRIPTION
Reverts #162)

fixes #170

This reverts commit da9cac9f97b44712c062682d3e14d2a4f2c309f6.

There are systems with old glibc versions.