### PR TITLE
chore: release v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6](https://github.com/Boshen/cargo-shear/compare/v1.2.5...v1.2.6) - 2025-04-25
+
+### Other
+
+- use `ubuntu-22.04` instead of `ubuntu-latest` to build
+- Reapply "perf: Use mimalloc on pre-built binaries. " ([#171](https://github.com/Boshen/cargo-shear/pull/171))
+
 ## [1.2.5](https://github.com/Boshen/cargo-shear/compare/v1.2.4...v1.2.5) - 2025-04-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.2.5"
+version = "1.2.6"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.2.5 -> 1.2.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.6](https://github.com/Boshen/cargo-shear/compare/v1.2.5...v1.2.6) - 2025-04-25

### Other

- use `ubuntu-22.04` instead of `ubuntu-latest` to build
- Reapply "perf: Use mimalloc on pre-built binaries. " ([#171](https://github.com/Boshen/cargo-shear/pull/171))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).