### PR TITLE
fix: handle whitespace in derive macro path `thiserror :: Error`

### DIFF
--- a/src/import_collector.rs
+++ b/src/import_collector.rs
@@ -80,7 +80,7 @@ impl ImportCollector {
         let Some(source_text) = tokens.span().source_text() else { return };
         let idents = MACRO_RE
             .get_or_init(|| {
-                Regex::new(r"(\w+)::(\w+)")
+                Regex::new(r"(\w+)[\s]*::[\s]*(\w+)")
                     .unwrap_or_else(|e| panic!("Failed to parse regex {e:?}"))
             })
             .captures_iter(&source_text)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,6 +35,10 @@ fn use_group() {
 #[test]
 fn meta_list() {
     test("#[derive(foo::Deserialize, foo::Serialize)] struct Foo;");
+    test("#[derive(foo :: Deserialize, Debug)] struct Foo;");
+    test("#[derive(foo:: Deserialize, Debug)] struct Foo;");
+    test("#[derive(foo ::Deserialize, Debug)] struct Foo;");
+    test("#[derive(foo        ::       Deserialize, Debug)] struct Foo;");
 }
 
 #[test]


### PR DESCRIPTION
fixes #175