### PR TITLE
chore: release v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.8](https://github.com/Boshen/cargo-shear/compare/v1.2.7...v1.2.8) - 2025-05-21
+
+### Other
+
+- improve ignore hint ([#188](https://github.com/Boshen/cargo-shear/pull/188))
+- *(deps)* update github-actions ([#185](https://github.com/Boshen/cargo-shear/pull/185))
+- *(deps)* lock file maintenance rust crates ([#186](https://github.com/Boshen/cargo-shear/pull/186))
+- *(deps)* update dependency rust to v1.87.0 ([#183](https://github.com/Boshen/cargo-shear/pull/183))
+- *(deps)* update github-actions ([#180](https://github.com/Boshen/cargo-shear/pull/180))
+
 ## [1.2.7](https://github.com/Boshen/cargo-shear/compare/v1.2.6...v1.2.7) - 2025-05-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.2.7"
+version = "1.2.8"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.2.7"
+version = "1.2.8"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.2.7 -> 1.2.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.8](https://github.com/Boshen/cargo-shear/compare/v1.2.7...v1.2.8) - 2025-05-21

### Other

- improve ignore hint ([#188](https://github.com/Boshen/cargo-shear/pull/188))
- *(deps)* update github-actions ([#185](https://github.com/Boshen/cargo-shear/pull/185))
- *(deps)* lock file maintenance rust crates ([#186](https://github.com/Boshen/cargo-shear/pull/186))
- *(deps)* update dependency rust to v1.87.0 ([#183](https://github.com/Boshen/cargo-shear/pull/183))
- *(deps)* update github-actions ([#180](https://github.com/Boshen/cargo-shear/pull/180))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).