### PR TITLE
feat: return exit code when `--fix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ The exit code gives an indication whether unused dependencies have been found:
 * 1 if it found at least one unused dependency,
 * 2 if there was an error during processing (in which case there's no indication whether any unused dependency was found or not).
 
+With `--fix`:
+
+* 0 if found no unused dependencies so no fixes were performed,
+* 1 if removed some unused dependencies. Useful for running `cargo check` after `cargo-shear` changed `Cargo.toml`.
+
 ## Technique
 
 1. use the `cargo_metadata` crate to list all dependencies specified in `[workspace.dependencies]` and `[dependencies]`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,11 @@ impl CargoShear {
                 let has_fixed = self.fixed_dependencies > 0;
 
                 if has_fixed {
-                    println!("Fixed {} dependencies!", self.fixed_dependencies);
+                    println!(
+                        "Fixed {} {}.\n",
+                        self.fixed_dependencies,
+                        if self.fixed_dependencies == 1 { "dependency" } else { "dependencies" }
+                    );
                 }
 
                 let has_deps = (self.unused_dependencies - self.fixed_dependencies) > 0;
@@ -101,8 +105,7 @@ impl CargoShear {
                     println!("No unused dependencies!");
                 }
 
-                // returns 0 if no deps, 1 if has deps
-                ExitCode::from(u8::from(has_deps))
+                ExitCode::from(u8::from(if self.options.fix { has_fixed } else { has_deps }))
             }
             Err(err) => {
                 println!("{err}");


### PR DESCRIPTION
closes #147

For CI:

With `--fix`:

* 0 if found no unused dependencies so no fixes were performed,
* 1 if removed some unused dependencies. Useful for running `cargo check` after `cargo-shear` changed `Cargo.toml`.