### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1](https://github.com/Boshen/cargo-shear/compare/v1.3.0...v1.3.1) - 2025-06-02
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#195](https://github.com/Boshen/cargo-shear/pull/195))
+- *(deps)* update taiki-e/install-action action to v2.52.4 ([#194](https://github.com/Boshen/cargo-shear/pull/194))
+- *(deps)* lock file maintenance rust crates ([#193](https://github.com/Boshen/cargo-shear/pull/193))
+- *(deps)* update taiki-e/install-action action to v2.52.1 ([#192](https://github.com/Boshen/cargo-shear/pull/192))
+- add fix example
+
 ## [1.3.0](https://github.com/Boshen/cargo-shear/compare/v1.2.8...v1.3.0) - 2025-05-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.3.0 -> 1.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.1](https://github.com/Boshen/cargo-shear/compare/v1.3.0...v1.3.1) - 2025-06-02

### Other

- *(deps)* lock file maintenance rust crates ([#195](https://github.com/Boshen/cargo-shear/pull/195))
- *(deps)* update taiki-e/install-action action to v2.52.4 ([#194](https://github.com/Boshen/cargo-shear/pull/194))
- *(deps)* lock file maintenance rust crates ([#193](https://github.com/Boshen/cargo-shear/pull/193))
- *(deps)* update taiki-e/install-action action to v2.52.1 ([#192](https://github.com/Boshen/cargo-shear/pull/192))
- add fix example
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).