### PR TITLE
chore: release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2](https://github.com/Boshen/cargo-shear/compare/v1.3.1...v1.3.2) - 2025-06-29
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#210](https://github.com/Boshen/cargo-shear/pull/210))
+- *(deps)* update github-actions ([#209](https://github.com/Boshen/cargo-shear/pull/209))
+- *(deps)* update dependency rust to v1.88.0 ([#208](https://github.com/Boshen/cargo-shear/pull/208))
+- *(deps)* update taiki-e/install-action action to v2.54.0 ([#207](https://github.com/Boshen/cargo-shear/pull/207))
+- *(deps)* lock file maintenance rust crates ([#205](https://github.com/Boshen/cargo-shear/pull/205))
+- *(deps)* update github-actions ([#204](https://github.com/Boshen/cargo-shear/pull/204))
+- *(deps)* lock file maintenance rust crates ([#203](https://github.com/Boshen/cargo-shear/pull/203))
+- *(deps)* update github-actions ([#202](https://github.com/Boshen/cargo-shear/pull/202))
+- *(deps)* lock file maintenance rust crates ([#200](https://github.com/Boshen/cargo-shear/pull/200))
+- *(deps)* update github-actions ([#199](https://github.com/Boshen/cargo-shear/pull/199))
+- *(README)* add turbopack to trophy case
+- *(deps)* update crate-ci/typos action to v1.33.1 ([#198](https://github.com/Boshen/cargo-shear/pull/198))
+- *(deps)* update crate-ci/typos action to v1.33.0 ([#196](https://github.com/Boshen/cargo-shear/pull/196))
+
 ## [1.3.1](https://github.com/Boshen/cargo-shear/compare/v1.3.0...v1.3.1) - 2025-06-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.3.1 -> 1.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.2](https://github.com/Boshen/cargo-shear/compare/v1.3.1...v1.3.2) - 2025-06-29

### Other

- *(deps)* lock file maintenance rust crates ([#210](https://github.com/Boshen/cargo-shear/pull/210))
- *(deps)* update github-actions ([#209](https://github.com/Boshen/cargo-shear/pull/209))
- *(deps)* update dependency rust to v1.88.0 ([#208](https://github.com/Boshen/cargo-shear/pull/208))
- *(deps)* update taiki-e/install-action action to v2.54.0 ([#207](https://github.com/Boshen/cargo-shear/pull/207))
- *(deps)* lock file maintenance rust crates ([#205](https://github.com/Boshen/cargo-shear/pull/205))
- *(deps)* update github-actions ([#204](https://github.com/Boshen/cargo-shear/pull/204))
- *(deps)* lock file maintenance rust crates ([#203](https://github.com/Boshen/cargo-shear/pull/203))
- *(deps)* update github-actions ([#202](https://github.com/Boshen/cargo-shear/pull/202))
- *(deps)* lock file maintenance rust crates ([#200](https://github.com/Boshen/cargo-shear/pull/200))
- *(deps)* update github-actions ([#199](https://github.com/Boshen/cargo-shear/pull/199))
- *(README)* add turbopack to trophy case
- *(deps)* update crate-ci/typos action to v1.33.1 ([#198](https://github.com/Boshen/cargo-shear/pull/198))
- *(deps)* update crate-ci/typos action to v1.33.0 ([#196](https://github.com/Boshen/cargo-shear/pull/196))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).