### PR TITLE
chore: release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3](https://github.com/Boshen/cargo-shear/compare/v1.3.2...v1.3.3) - 2025-07-04
+
+### Fixed
+
+- add file type check ([#214](https://github.com/Boshen/cargo-shear/pull/214))
+
+### Other
+
+- *(deps)* update crate-ci/typos action to v1.34.0 ([#212](https://github.com/Boshen/cargo-shear/pull/212))
+
 ## [1.3.2](https://github.com/Boshen/cargo-shear/compare/v1.3.1...v1.3.2) - 2025-06-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.3.2 -> 1.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.3](https://github.com/Boshen/cargo-shear/compare/v1.3.2...v1.3.3) - 2025-07-04

### Fixed

- add file type check ([#214](https://github.com/Boshen/cargo-shear/pull/214))

### Other

- *(deps)* update crate-ci/typos action to v1.34.0 ([#212](https://github.com/Boshen/cargo-shear/pull/212))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).