### PR TITLE
feat: print backtrace when resulting errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod import_collector;
 mod tests;
 
 use std::{
+    backtrace::BacktraceStatus,
     collections::{HashMap, HashSet},
     env,
     ffi::OsString,
@@ -108,7 +109,12 @@ impl CargoShear {
                 ExitCode::from(u8::from(if self.options.fix { has_fixed } else { has_deps }))
             }
             Err(err) => {
-                println!("{err}");
+                println!("{err:?}");
+                if err.backtrace().status() == BacktraceStatus::Disabled {
+                    println!(
+                        "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+                    );
+                }
                 ExitCode::from(2)
             }
         }


### PR DESCRIPTION
It is said in the [`anyhow::Error` docs](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations)
> The Debug format “{:?}” includes your backtrace if one was captured. Note that this is the representation you get by default if you return an error from fn main instead of printing it explicitly yourself.

Usually the `Error` is handle with `.unwrap` or other functions which finally call `panic`. And the panic handler in rust std will give a friendly tip if the backtrace is disabled. However, `cargo-shear` doesn't call panic but customize its exit code instead, so that's the reason why I also add this tip. Feel free to remove it if you think this is a bad design :)