### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0](https://github.com/Boshen/cargo-shear/compare/v1.3.3...v1.4.0) - 2025-07-14
+
+### Added
+
+- print backtrace when resulting errors ([#215](https://github.com/Boshen/cargo-shear/pull/215))
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#221](https://github.com/Boshen/cargo-shear/pull/221))
+- *(deps)* update taiki-e/install-action action to v2.56.13 ([#220](https://github.com/Boshen/cargo-shear/pull/220))
+- *(deps)* lock file maintenance ([#218](https://github.com/Boshen/cargo-shear/pull/218))
+- *(deps)* update github-actions ([#217](https://github.com/Boshen/cargo-shear/pull/217))
+
 ## [1.3.3](https://github.com/Boshen/cargo-shear/compare/v1.3.2...v1.3.3) - 2025-07-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.3.3"
+version = "1.4.0"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.3.3 -> 1.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.0](https://github.com/Boshen/cargo-shear/compare/v1.3.3...v1.4.0) - 2025-07-14

### Added

- print backtrace when resulting errors ([#215](https://github.com/Boshen/cargo-shear/pull/215))

### Other

- *(deps)* lock file maintenance rust crates ([#221](https://github.com/Boshen/cargo-shear/pull/221))
- *(deps)* update taiki-e/install-action action to v2.56.13 ([#220](https://github.com/Boshen/cargo-shear/pull/220))
- *(deps)* lock file maintenance ([#218](https://github.com/Boshen/cargo-shear/pull/218))
- *(deps)* update github-actions ([#217](https://github.com/Boshen/cargo-shear/pull/217))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).