### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.4.1](https://github.com/Boshen/cargo-shear/compare/v1.4.0...v1.4.1) - 2025-07-28
+
+### Other
+
+- *(release)* enable trusted publishing
+- *(deps)* lock file maintenance rust crates ([#226](https://github.com/Boshen/cargo-shear/pull/226))
+- *(deps)* update github-actions ([#225](https://github.com/Boshen/cargo-shear/pull/225))
+- *(deps)* lock file maintenance rust crates ([#223](https://github.com/Boshen/cargo-shear/pull/223))
+- *(deps)* update github-actions ([#222](https://github.com/Boshen/cargo-shear/pull/222))
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.4.0 -> 1.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.1](https://github.com/Boshen/cargo-shear/compare/v1.4.0...v1.4.1) - 2025-07-28

### Other

- *(release)* enable trusted publishing
- *(deps)* lock file maintenance rust crates ([#226](https://github.com/Boshen/cargo-shear/pull/226))
- *(deps)* update github-actions ([#225](https://github.com/Boshen/cargo-shear/pull/225))
- *(deps)* lock file maintenance rust crates ([#223](https://github.com/Boshen/cargo-shear/pull/223))
- *(deps)* update github-actions ([#222](https://github.com/Boshen/cargo-shear/pull/222))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).