### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/Boshen/cargo-shear/compare/v1.4.1...v1.5.0) - 2025-08-11
+
+### Added
+
+- improve logging for file read and parse ([#240](https://github.com/Boshen/cargo-shear/pull/240))
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#239](https://github.com/Boshen/cargo-shear/pull/239))
+- *(deps)* lock file maintenance rust crates ([#238](https://github.com/Boshen/cargo-shear/pull/238))
+- *(deps)* update github-actions ([#237](https://github.com/Boshen/cargo-shear/pull/237))
+- *(deps)* update crate-ci/typos action to v1.35.3 ([#235](https://github.com/Boshen/cargo-shear/pull/235))
+- *(deps)* update crate-ci/typos action to v1.35.2 ([#234](https://github.com/Boshen/cargo-shear/pull/234))
+- *(deps)* update dependency rust to v1.89.0 ([#233](https://github.com/Boshen/cargo-shear/pull/233))
+- *(deps)* update crate-ci/typos action to v1.35.1 ([#232](https://github.com/Boshen/cargo-shear/pull/232))
+- *(deps)* lock file maintenance rust crates ([#230](https://github.com/Boshen/cargo-shear/pull/230))
+- *(deps)* update github-actions ([#229](https://github.com/Boshen/cargo-shear/pull/229))
+
 ## [1.4.1](https://github.com/Boshen/cargo-shear/compare/v1.4.0...v1.4.1) - 2025-07-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.4.1 -> 1.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.0](https://github.com/Boshen/cargo-shear/compare/v1.4.1...v1.5.0) - 2025-08-11

### Added

- improve logging for file read and parse ([#240](https://github.com/Boshen/cargo-shear/pull/240))

### Other

- *(deps)* lock file maintenance rust crates ([#239](https://github.com/Boshen/cargo-shear/pull/239))
- *(deps)* lock file maintenance rust crates ([#238](https://github.com/Boshen/cargo-shear/pull/238))
- *(deps)* update github-actions ([#237](https://github.com/Boshen/cargo-shear/pull/237))
- *(deps)* update crate-ci/typos action to v1.35.3 ([#235](https://github.com/Boshen/cargo-shear/pull/235))
- *(deps)* update crate-ci/typos action to v1.35.2 ([#234](https://github.com/Boshen/cargo-shear/pull/234))
- *(deps)* update dependency rust to v1.89.0 ([#233](https://github.com/Boshen/cargo-shear/pull/233))
- *(deps)* update crate-ci/typos action to v1.35.1 ([#232](https://github.com/Boshen/cargo-shear/pull/232))
- *(deps)* lock file maintenance rust crates ([#230](https://github.com/Boshen/cargo-shear/pull/230))
- *(deps)* update github-actions ([#229](https://github.com/Boshen/cargo-shear/pull/229))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).