### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1](https://github.com/Boshen/cargo-shear/compare/v1.5.0...v1.5.1) - 2025-08-12
+
+### Other
+
+- *(deps)* update crate-ci/typos action to v1.35.4 ([#241](https://github.com/Boshen/cargo-shear/pull/241))
+
 ## [1.5.0](https://github.com/Boshen/cargo-shear/compare/v1.4.1...v1.5.0) - 2025-08-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.5.0 -> 1.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.1](https://github.com/Boshen/cargo-shear/compare/v1.5.0...v1.5.1) - 2025-08-12

### Other

- *(deps)* update crate-ci/typos action to v1.35.4 ([#241](https://github.com/Boshen/cargo-shear/pull/241))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).