### PR TITLE
chore: release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1](https://github.com/Boshen/cargo-shear/compare/v1.6.0...v1.6.1) - 2025-10-27
+
+### Fixed
+
+- treat ignored packages as used on the workspace level ([#295](https://github.com/Boshen/cargo-shear/pull/295))
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#294](https://github.com/Boshen/cargo-shear/pull/294))
+- *(deps)* update github-actions ([#293](https://github.com/Boshen/cargo-shear/pull/293))
+- *(deps)* lock file maintenance rust crates ([#291](https://github.com/Boshen/cargo-shear/pull/291))
+- *(deps)* update github-actions ([#290](https://github.com/Boshen/cargo-shear/pull/290))
+
 ## [1.6.0](https://github.com/Boshen/cargo-shear/compare/v1.5.2...v1.6.0) - 2025-10-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.6.0 -> 1.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.6.1](https://github.com/Boshen/cargo-shear/compare/v1.6.0...v1.6.1) - 2025-10-27

### Fixed

- treat ignored packages as used on the workspace level ([#295](https://github.com/Boshen/cargo-shear/pull/295))

### Other

- *(deps)* lock file maintenance rust crates ([#294](https://github.com/Boshen/cargo-shear/pull/294))
- *(deps)* update github-actions ([#293](https://github.com/Boshen/cargo-shear/pull/293))
- *(deps)* lock file maintenance rust crates ([#291](https://github.com/Boshen/cargo-shear/pull/291))
- *(deps)* update github-actions ([#290](https://github.com/Boshen/cargo-shear/pull/290))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).