### PR TITLE
chore: release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2](https://github.com/Boshen/cargo-shear/compare/v1.6.1...v1.6.2) - 2025-11-04
+
+### Fixed
+
+- preserve attributes in doc blocks normalizer ([#301](https://github.com/Boshen/cargo-shear/pull/301))
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#300](https://github.com/Boshen/cargo-shear/pull/300))
+- *(deps)* update github-actions ([#299](https://github.com/Boshen/cargo-shear/pull/299))
+- *(deps)* update crate-ci/typos action to v1.39.0 ([#298](https://github.com/Boshen/cargo-shear/pull/298))
+- *(deps)* update dependency rust to v1.91.0 ([#296](https://github.com/Boshen/cargo-shear/pull/296))
+
 ## [1.6.1](https://github.com/Boshen/cargo-shear/compare/v1.6.0...v1.6.1) - 2025-10-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 description = "Detect and remove unused dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.6.1 -> 1.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.6.2](https://github.com/Boshen/cargo-shear/compare/v1.6.1...v1.6.2) - 2025-11-04

### Fixed

- preserve attributes in doc blocks normalizer ([#301](https://github.com/Boshen/cargo-shear/pull/301))

### Other

- *(deps)* lock file maintenance rust crates ([#300](https://github.com/Boshen/cargo-shear/pull/300))
- *(deps)* update github-actions ([#299](https://github.com/Boshen/cargo-shear/pull/299))
- *(deps)* update crate-ci/typos action to v1.39.0 ([#298](https://github.com/Boshen/cargo-shear/pull/298))
- *(deps)* update dependency rust to v1.91.0 ([#296](https://github.com/Boshen/cargo-shear/pull/296))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).