### PR TITLE
Detect and fix misplaced dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-shear"
 version = "1.6.4"
 edition = "2024"
-description = "Detect and remove unused dependencies from Cargo.toml"
+description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]
 repository = "https://github.com/Boshen/cargo-shear"
 keywords = ["cargo", "udeps", "machete", "unused", "dependencies"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cargo Shear ✂️ 🐑
 
-Detect and remove unused dependencies from `Cargo.toml` in Rust projects.
+Detect and fix unused/misplaced dependencies from `Cargo.toml` in Rust projects.
 
 ## Installation
 
@@ -21,7 +21,7 @@ brew install cargo-shear
 cargo shear --fix
 ```
 
-## Limitation
+## Limitations
 
 > [!IMPORTANT]
 > `cargo shear` cannot detect "hidden" imports from macro expansions without the `--expand` flag (nightly only).
@@ -34,6 +34,10 @@ cargo shear --expand --fix
 ```
 
 The `--expand` flag uses `cargo expand`, which requires nightly and is significantly slower.
+
+> [!IMPORTANT]
+> Misplaced dependency detection only works for integration tests, benchmarks, and examples.
+> Unit tests dependencies within `#[cfg(test)]` cannot be detected as misplaced.
 
 ## Ignore false positives
 

--- a/tests/fixtures/misplaced/src/lib.rs
+++ b/tests/fixtures/misplaced/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test() -> anyhow::Result<()> {
-        Ok(())
-    }
-}
+

--- a/tests/fixtures/misplaced/tests/test.rs
+++ b/tests/fixtures/misplaced/tests/test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/tests/fixtures/misplaced_optional/src/lib.rs
+++ b/tests/fixtures/misplaced_optional/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test() -> anyhow::Result<()> {
-        Ok(())
-    }
-}
+

--- a/tests/fixtures/misplaced_optional/tests/test.rs
+++ b/tests/fixtures/misplaced_optional/tests/test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/tests/fixtures/misplaced_renamed/src/lib.rs
+++ b/tests/fixtures/misplaced_renamed/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test() -> anyhow_v1::Result<()> {
-        Ok(())
-    }
-}
+

--- a/tests/fixtures/misplaced_renamed/tests/test.rs
+++ b/tests/fixtures/misplaced_renamed/tests/test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test() -> anyhow_v1::Result<()> {
+    Ok(())
+}

--- a/tests/fixtures/misplaced_table/src/lib.rs
+++ b/tests/fixtures/misplaced_table/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test() -> anyhow::Result<()> {
-        Ok(())
-    }
-}
+

--- a/tests/fixtures/misplaced_table/tests/test.rs
+++ b/tests/fixtures/misplaced_table/tests/test.rs
@@ -1,0 +1,4 @@
+#[test]
+fn test() -> anyhow::Result<()> {
+    Ok(())
+}

--- a/tests/fixtures/misplaced_unit/Cargo.toml
+++ b/tests/fixtures/misplaced_unit/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "misplaced_unit"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# Misplaced
+anyhow = "1.0"

--- a/tests/fixtures/misplaced_unit/src/lib.rs
+++ b/tests/fixtures/misplaced_unit/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test() -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -63,7 +63,7 @@ fn clean_detection() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -93,7 +93,7 @@ fn clean_workspace_detection() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -124,7 +124,7 @@ fn ignored() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -141,7 +141,7 @@ fn ignored_invalid() -> Result<(), Box<dyn Error>> {
 
     warning: 'anywho' is redundant in [package.metadata.cargo-shear] for package 'ignored_invalid'.
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -158,7 +158,7 @@ fn ignored_redundant() -> Result<(), Box<dyn Error>> {
 
     warning: 'anyhow' is redundant in [package.metadata.cargo-shear] for package 'ignored_redundant'.
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -173,7 +173,7 @@ fn ignored_workspace() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -188,7 +188,7 @@ fn ignored_workspace_merged() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -196,19 +196,35 @@ fn ignored_workspace_merged() -> Result<(), Box<dyn Error>> {
 
 // `anyhow` is only used in tests but declared in `dependencies` instead of `dev-dependencies`.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("misplaced", false)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
 
-    insta::assert_snapshot!(output, @"");
+    insta::assert_snapshot!(output, @r#"
+    Analyzing .
+
+    misplaced -- Cargo.toml:
+      misplaced dev dependencies:
+        anyhow
+
+
+    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
+    They can be ignored by adding the crate name to the package's Cargo.toml:
+
+    [package.metadata.cargo-shear]
+    ignored = ["crate-name"]
+
+    or in the workspace Cargo.toml:
+
+    [workspace.metadata.cargo-shear]
+    ignored = ["crate-name"]
+    "#);
 
     Ok(())
 }
 
 // `anyhow` should be moved from `dependencies` to `dev-dependencies`.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_fix() -> Result<(), Box<dyn Error>> {
     let (exit_code, _, temp_dir) = run_cargo_shear("misplaced", true)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
@@ -222,19 +238,21 @@ fn misplaced_fix() -> Result<(), Box<dyn Error>> {
 
 // Optional `anyhow` is only used in tests but declared in `dependencies`.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_optional_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("misplaced_optional", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @"");
+    insta::assert_snapshot!(output, @r"
+    Analyzing .
+
+    No issues detected!
+    ");
 
     Ok(())
 }
 
 // Optional `anyhow` can't be moved to `dev-dependencies` since they don't support `optional = true`.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_optional_fix() -> Result<(), Box<dyn Error>> {
     let (exit_code, _, temp_dir) = run_cargo_shear("misplaced_optional", true)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
@@ -248,19 +266,35 @@ fn misplaced_optional_fix() -> Result<(), Box<dyn Error>> {
 
 // Renamed dependency `anyhow_v1` is only used in tests but declared in `dependencies`.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_renamed_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("misplaced_renamed", false)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
 
-    insta::assert_snapshot!(output, @"");
+    insta::assert_snapshot!(output, @r#"
+    Analyzing .
+
+    misplaced_renamed -- Cargo.toml:
+      misplaced dev dependencies:
+        anyhow_v1
+
+
+    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
+    They can be ignored by adding the crate name to the package's Cargo.toml:
+
+    [package.metadata.cargo-shear]
+    ignored = ["crate-name"]
+
+    or in the workspace Cargo.toml:
+
+    [workspace.metadata.cargo-shear]
+    ignored = ["crate-name"]
+    "#);
 
     Ok(())
 }
 
 // Renamed `anyhow_v1` should be moved to `dev-dependencies` while maintaining package details.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_renamed_fix() -> Result<(), Box<dyn Error>> {
     let (exit_code, _, temp_dir) = run_cargo_shear("misplaced_renamed", true)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
@@ -278,19 +312,35 @@ fn misplaced_renamed_fix() -> Result<(), Box<dyn Error>> {
 
 // Table syntax `anyhow` is only used in tests but declared in `dependencies`.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_table_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("misplaced_table", false)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
 
-    insta::assert_snapshot!(output, @"");
+    insta::assert_snapshot!(output, @r#"
+    Analyzing .
+
+    misplaced_table -- Cargo.toml:
+      misplaced dev dependencies:
+        anyhow
+
+
+    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
+    They can be ignored by adding the crate name to the package's Cargo.toml:
+
+    [package.metadata.cargo-shear]
+    ignored = ["crate-name"]
+
+    or in the workspace Cargo.toml:
+
+    [workspace.metadata.cargo-shear]
+    ignored = ["crate-name"]
+    "#);
 
     Ok(())
 }
 
 // Table syntax `anyhow` should be moved to `dev-dependencies` while maintaining package details.
 #[test]
-#[ignore = "Unimplemented: #47"]
 fn misplaced_table_fix() -> Result<(), Box<dyn Error>> {
     let (exit_code, _, temp_dir) = run_cargo_shear("misplaced_table", true)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
@@ -307,6 +357,32 @@ fn misplaced_table_fix() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// `anyhow` is only used in unit tests but declared in `dependencies` instead of `dev-dependencies`.
+#[test]
+#[ignore = "Cannot detect misplaced dependencies in unit tests"]
+fn misplaced_unit_detection() -> Result<(), Box<dyn Error>> {
+    let (exit_code, output, _) = run_cargo_shear("misplaced_unit", false)?;
+    assert_eq!(exit_code, ExitCode::SUCCESS);
+
+    insta::assert_snapshot!(output, @"");
+
+    Ok(())
+}
+
+// `anyhow` should be moved from `dependencies` to `dev-dependencies`.
+#[test]
+#[ignore = "Cannot detect misplaced dependencies in unit tests"]
+fn misplaced_unit_fix() -> Result<(), Box<dyn Error>> {
+    let (exit_code, _, temp_dir) = run_cargo_shear("misplaced_unit", true)?;
+    assert_eq!(exit_code, ExitCode::FAILURE);
+
+    let manifest = Manifest::from_path(temp_dir.path().join("Cargo.toml"))?;
+    assert!(manifest.dev_dependencies.contains_key("anyhow"));
+    assert!(!manifest.dependencies.contains_key("anyhow"));
+
+    Ok(())
+}
+
 // `anyhow` is unused.
 #[test]
 fn unused_detection() -> Result<(), Box<dyn Error>> {
@@ -317,7 +393,8 @@ fn unused_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused -- Cargo.toml:
-      anyhow
+      unused dependencies:
+        anyhow
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -357,7 +434,8 @@ fn unused_build_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_build -- Cargo.toml:
-      anyhow
+      unused dependencies:
+        anyhow
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -397,7 +475,8 @@ fn unused_dev_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_dev -- Cargo.toml:
-      anyhow
+      unused dependencies:
+        anyhow
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -436,7 +515,7 @@ fn unused_feature_detect() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -463,7 +542,7 @@ fn unused_feature_weak_detect() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -491,7 +570,8 @@ fn unused_naming_hyphen_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_naming_hyphen -- Cargo.toml:
-      serde_json
+      unused dependencies:
+        serde_json
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -531,7 +611,8 @@ fn unused_naming_underscore_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_naming_underscore -- Cargo.toml:
-      rustc-hash
+      unused dependencies:
+        rustc-hash
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -570,7 +651,7 @@ fn unused_optional_detection() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -601,7 +682,7 @@ fn unused_optional_implicit_detection() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    No unused dependencies!
+    No issues detected!
     ");
 
     Ok(())
@@ -629,7 +710,8 @@ fn unused_platform_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_platform -- Cargo.toml:
-      anyhow
+      unused dependencies:
+        anyhow
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -670,7 +752,8 @@ fn unused_renamed_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_renamed -- Cargo.toml:
-      anyhow_v1
+      unused dependencies:
+        anyhow_v1
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -710,7 +793,8 @@ fn unused_table_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     unused_table -- Cargo.toml:
-      anyhow
+      unused dependencies:
+        anyhow
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -750,7 +834,8 @@ fn unused_workspace_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     root -- ./Cargo.toml:
-      anyhow
+      unused dependencies:
+        anyhow
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.
@@ -791,7 +876,8 @@ fn unused_workspace_renamed_detection() -> Result<(), Box<dyn Error>> {
     Analyzing .
 
     root -- ./Cargo.toml:
-      anyhow_v1
+      unused dependencies:
+        anyhow_v1
 
 
     cargo-shear may have detected unused dependencies incorrectly due to its limitations.


### PR DESCRIPTION
Resolves #47

Categorizes imports based on target, so we can now detect and fix dependencies that should be moved to dev-dependencies.

Here's an example of the new output:

```bash
> cargo shear --expand --fix
Analyzing /home/cmullan/workspace/rustls

rustls-connect-tests -- connect-tests/Cargo.toml:
  unused dependencies:
    tokio
    ring
    rustls

rustls-examples -- examples/Cargo.toml:
  unused dependencies:
    serde

rustls-post-quantum -- rustls-post-quantum/Cargo.toml:
  unused dependencies:
    rustls-test

rustls-provider-example -- provider-example/Cargo.toml:
  unused dependencies:
    ecdsa

rustls-provider-test -- rustls-provider-test/Cargo.toml:
  misplaced dev dependencies:
    hex
    serde_json
    rustls
    provider-example
    serde

root -- Cargo.toml:
  unused dependencies:
    ecdsa

Fixed 12 dependencies.

No issues detected!
```

One limitation here is that unit tests dependencies get categorized as part of the lib/bin target. A workaround for that in the future could be to use syn to extract `#[cfg(test)]` imports separately.
