### PR TITLE
chore: release v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.5](https://github.com/Boshen/cargo-shear/compare/v1.6.4...v1.6.5) - 2025-11-24
+
+### Other
+
+- Improve error reporting for misplaced deps, and mention fix flag if not used ([#318](https://github.com/Boshen/cargo-shear/pull/318))
+- *(deps)* update rust crate syn to v2.0.111 ([#320](https://github.com/Boshen/cargo-shear/pull/320))
+- *(deps)* update github-actions ([#319](https://github.com/Boshen/cargo-shear/pull/319))
+- Detect and fix misplaced dev dependencies ([#316](https://github.com/Boshen/cargo-shear/pull/316))
+
 ## [1.6.4](https://github.com/Boshen/cargo-shear/compare/v1.6.3...v1.6.4) - 2025-11-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.6.4 -> 1.6.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.6.5](https://github.com/Boshen/cargo-shear/compare/v1.6.4...v1.6.5) - 2025-11-24

### Other

- Improve error reporting for misplaced deps, and mention fix flag if not used ([#318](https://github.com/Boshen/cargo-shear/pull/318))
- *(deps)* update rust crate syn to v2.0.111 ([#320](https://github.com/Boshen/cargo-shear/pull/320))
- *(deps)* update github-actions ([#319](https://github.com/Boshen/cargo-shear/pull/319))
- Detect and fix misplaced dev dependencies ([#316](https://github.com/Boshen/cargo-shear/pull/316))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).