### PR TITLE
Switch from `syn` to `ra_ap_syntax` for parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bpaf"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,11 +78,10 @@ dependencies = [
  "cargo_toml",
  "insta",
  "mimalloc-safe",
- "proc-macro2",
+ "ra_ap_syntax",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde_json",
- "syn",
  "tempfile",
  "toml_edit",
  "walkdir",
@@ -136,6 +144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +168,21 @@ dependencies = [
  "libc",
  "once_cell",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -191,6 +220,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
 name = "either"
@@ -263,6 +298,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -379,7 +420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -394,10 +435,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jod-thread"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a037eddb7d28de1d0fc42411f501b53b75838d313908078d6698d064f3029b24"
 
 [[package]]
 name = "libc"
@@ -435,12 +491,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc-safe"
 version = "0.1.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664f11d12bce99bf21ef61c1949a88dc34440de83dd1b8dcb0b636b74b1d7e21"
 dependencies = [
  "libmimalloc-sys2",
+]
+
+[[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -472,6 +546,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "potential_utf"
@@ -507,6 +587,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ra-ap-rustc_lexer"
+version = "0.137.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac80365383a3c749f38af567fdcfaeff3fa6ea5df3846852abbce73e943921b9"
+dependencies = [
+ "memchr",
+ "unicode-properties",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ra_ap_edition"
+version = "0.0.307"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827b826e17647842049aa07bb4f75d78516ddcb32d651307de6b2891d9349396"
+
+[[package]]
+name = "ra_ap_parser"
+version = "0.0.307"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2876e07c278c85cb458f0fe1a9679a48d561a95868e67b465fb328458506867"
+dependencies = [
+ "drop_bomb",
+ "ra-ap-rustc_lexer",
+ "ra_ap_edition",
+ "rustc-literal-escaper",
+ "tracing",
+ "winnow",
+]
+
+[[package]]
+name = "ra_ap_stdx"
+version = "0.0.307"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd94073132b765585a905d68352e5a9a0513d66e0da7186892cebc033fd347ee"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "itertools",
+ "jod-thread",
+ "libc",
+ "miow",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ra_ap_syntax"
+version = "0.0.307"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d3d6c19beb665511d026e513134b053282ec38e45d74f6a7a8287f79de90bc"
+dependencies = [
+ "either",
+ "itertools",
+ "ra_ap_parser",
+ "ra_ap_stdx",
+ "rowan",
+ "rustc-hash 2.1.1",
+ "rustc-literal-escaper",
+ "smol_str",
+ "tracing",
+ "triomphe",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,10 +672,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rowan"
+version = "0.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "memoffset",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-literal-escaper"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03008eb631b703dd16978282ae36c73282e7922fe101a4bd072a40ecea7b8b"
 
 [[package]]
 name = "rustix"
@@ -663,6 +833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498b0a27f93ef1402f20eefacfaa1691272ac4eca1cdc8c596cb0a245d6cbf5"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +882,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -786,6 +972,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +1007,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -861,7 +1078,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -879,14 +1105,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -896,10 +1139,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -908,10 +1163,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -920,10 +1187,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -932,10 +1211,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,7 @@ walkdir = "2.5.0"
 cargo_metadata = "0.23.0"
 cargo_toml = "0.22.1"
 bpaf = { version = "0.9.19", features = ["derive", "batteries"] }
-proc-macro2 = { version = "1.0.94", features = ["span-locations"] }
-syn = { version = "2.0.100", features = [
-  "full",
-  "visit",
-  "extra-traits", # add "extra-traits" to debug syn ast
-] }
+ra_ap_syntax = "0.0.307"
 rayon = "1.10.0"
 toml_edit = { version = "0.23.0", features = ["parse"] }
 anyhow = "1.0.97"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo shear --fix
 
 > [!IMPORTANT]
 > `cargo shear` cannot detect "hidden" imports from macro expansions without the `--expand` flag (nightly only).
-> This is because `cargo shear` uses `syn` to parse files and does not expand macros by default.
+> This is because `cargo shear` uses rust-analyzer's parser to parse files and does not expand macros by default.
 
 To expand macros:
 
@@ -97,7 +97,7 @@ GitHub Actions Job Example:
 
 1. use the `cargo_metadata` crate to list all dependencies specified in `[workspace.dependencies]` and `[dependencies]`
 2. iterate through all package targets (`lib`, `bin`, `example`, `test` and `bench`) to locate all Rust files
-3. use `syn` to parse these Rust files and extract imports
+3. use rust-analyzer's parser (`ra_ap_syntax`) to parse these Rust files and extract imports
   - alternatively, use the `--expand` option with `cargo expand` to first expand macros and then parse the expanded code (though this is significantly slower).
 4. find the difference between the imports and the package dependencies
 


### PR DESCRIPTION
Trying to run `cargo shear --expand` on the majority of Rust 1.88+ projects will  fail due to the use of `super let` by the `pin!` macro on nightly, which `syn` can't parse: https://github.com/rust-lang/rust/pull/139114

`syn` won't add support for parsing `super let` until it's closer to stabilization: https://github.com/dtolnay/syn/pull/1947

So I opted to switch to rust-analyzer's syntax parser instead. The API is pretty similar overall. Main benefit is it supports more experimental syntax. Though I'm not sure how stable it is, which might be a concern.

It's a more resilient parser, so it handles syntax errors gracefully. That might backfire in certain scenarios. 

With these changes, I was able to run `--expand` against the Zed monorepo, which found 100+ issues. 

<details>

```bash
Analyzing /home/cmullan/workspace/zed

acp_thread -- crates/acp_thread/Cargo.toml:
  unused dependencies:
    zlog
    tempfile

acp_tools -- crates/acp_tools/Cargo.toml:
  unused dependencies:
    serde

action_log -- crates/action_log/Cargo.toml:
  unused dependencies:
    indoc

agent -- crates/agent/Cargo.toml:
  unused dependencies:
    editor
    terminal
    worktree

agent_servers -- crates/agent_servers/Cargo.toml:
  unused dependencies:
    nix
    libc
    language

agent_settings -- crates/agent_settings/Cargo.toml:
  unused dependencies:
    serde_json_lenient
    serde_json
    paths

ai_onboarding -- crates/ai_onboarding/Cargo.toml:
  unused dependencies:
    serde

assistant_text_thread -- crates/assistant_text_thread/Cargo.toml:
  unused dependencies:
    indoc

audio -- crates/audio/Cargo.toml:
  unused dependencies:
    serde

buffer_diff -- crates/buffer_diff/Cargo.toml:
  unused dependencies:
    serde_json

call -- crates/call/Cargo.toml:
  unused dependencies:
    http_client
    serde

client -- crates/client/Cargo.toml:
  unused dependencies:
    fs

collab -- crates/collab/Cargo.toml:
  unused dependencies:
    context_server
    dap-types
    sea-orm-macros
    agent_settings
    hyper
    audio
    multi_buffer

collab_ui -- crates/collab_ui/Cargo.toml:
  unused dependencies:
    pretty_assertions
    tree-sitter-md

command_palette -- crates/command_palette/Cargo.toml:
  unused dependencies:
    env_logger
    serde_json
    ctor

copilot -- crates/copilot/Cargo.toml:
  unused dependencies:
    async-std
    clock
    client
    task

credentials_provider -- crates/credentials_provider/Cargo.toml:
  unused dependencies:
    serde

dap -- crates/dap/Cargo.toml:
  unused dependencies:
    tree-sitter
    tree-sitter-go

dap_adapters -- crates/dap_adapters/Cargo.toml:
  unused dependencies:
    serde

diagnostics -- crates/diagnostics/Cargo.toml:
  unused dependencies:
    serde
    client
    component

edit_prediction_button -- crates/edit_prediction_button/Cargo.toml:
  unused dependencies:
    theme
    lsp
    serde_json
    futures

edit_prediction_context -- crates/edit_prediction_context/Cargo.toml:
  unused dependencies:
    clap

editor -- crates/editor/Cargo.toml:
  unused dependencies:
    http_client
    tempfile

extension_cli -- crates/extension_cli/Cargo.toml:
  unused dependencies:
    serde

extensions_ui -- crates/extensions_ui/Cargo.toml:
  unused dependencies:
    serde

feedback -- crates/feedback/Cargo.toml:
  unused dependencies:
    editor

file_finder -- crates/file_finder/Cargo.toml:
  unused dependencies:
    language

file_icons -- crates/file_icons/Cargo.toml:
  unused dependencies:
    serde

git -- crates/git/Cargo.toml:
  unused dependencies:
    unindent

git_ui -- crates/git_ui/Cargo.toml:
  unused dependencies:
    windows

go_to_line -- crates/go_to_line/Cargo.toml:
  unused dependencies:
    tree-sitter-typescript
    serde
    tree-sitter-rust

gpui -- crates/gpui/Cargo.toml:
  unused dependencies:
    cocoa-foundation
    x11-clipboard
    pretty_assertions

image_viewer -- crates/image_viewer/Cargo.toml:
  unused dependencies:
    serde

journal -- crates/journal/Cargo.toml:
  unused dependencies:
    serde

json_schema_store -- crates/json_schema_store/Cargo.toml:
  unused dependencies:
    serde

keymap_editor -- crates/keymap_editor/Cargo.toml:
  unused dependencies:
    serde
    component

language_models -- crates/language_models/Cargo.toml:
  unused dependencies:
    project
    editor

languages -- crates/languages/Cargo.toml:
  unused dependencies:
    text
    rope
    workspace

livekit_client -- crates/livekit_client/Cargo.toml:
  unused dependencies:
    sha2
    serde_json
    objc

media -- crates/media/Cargo.toml:
  unused dependencies:
    ctor

multi_buffer -- crates/multi_buffer/Cargo.toml:
  unused dependencies:
    project

net -- crates/net/Cargo.toml:
  unused dependencies:
    anyhow

node_runtime -- crates/node_runtime/Cargo.toml:
  unused dependencies:
    async-std

notifications -- crates/notifications/Cargo.toml:
  unused dependencies:
    settings

outline -- crates/outline/Cargo.toml:
  unused dependencies:
    tree-sitter-typescript

picker -- crates/picker/Cargo.toml:
  unused dependencies:
    env_logger
    ctor

proto -- crates/proto/Cargo.toml:
  unused dependencies:
    typed-path

recent_projects -- crates/recent_projects/Cargo.toml:
  unused dependencies:
    serde
    dap
    task

remote_server -- crates/remote_server/Cargo.toml:
  unused dependencies:
    crash-handler
    git2
    minidumper
    serde
    dap
    workspace

repl -- crates/repl/Cargo.toml:
  unused dependencies:
    env_logger
    serde

reqwest_client -- crates/reqwest_client/Cargo.toml:
  unused dependencies:
    serde
    gpui

rules_library -- crates/rules_library/Cargo.toml:
  unused dependencies:
    serde

schema_generator -- crates/schema_generator/Cargo.toml:
  unused dependencies:
    serde

settings_profile_selector -- crates/settings_profile_selector/Cargo.toml:
  unused dependencies:
    client
    language

settings_ui -- crates/settings_ui/Cargo.toml:
  unused dependencies:
    futures
    zlog
    session
    node_runtime
    client
    assets
    language

supermaven -- crates/supermaven/Cargo.toml:
  unused dependencies:
    project
    theme
    http_client
    env_logger
    editor

tab_switcher -- crates/tab_switcher/Cargo.toml:
  unused dependencies:
    language
    anyhow

tasks_ui -- crates/tasks_ui/Cargo.toml:
  unused dependencies:
    serde

telemetry -- crates/telemetry/Cargo.toml:
  unused dependencies:
    serde

terminal_view -- crates/terminal_view/Cargo.toml:
  unused dependencies:
    rand
    client

text -- crates/text/Cargo.toml:
  unused dependencies:
    http_client

theme_selector -- crates/theme_selector/Cargo.toml:
  unused dependencies:
    serde

title_bar -- crates/title_bar/Cargo.toml:
  unused dependencies:
    pretty_assertions
    tree-sitter-md

ui -- crates/ui/Cargo.toml:
  unused dependencies:
    windows

util -- crates/util/Cargo.toml:
  unused dependencies:
    indoc

vim -- crates/vim/Cargo.toml:
  unused dependencies:
    assets

watch -- crates/watch/Cargo.toml:
  unused dependencies:
    rand

web_search -- crates/web_search/Cargo.toml:
  unused dependencies:
    serde

web_search_providers -- crates/web_search_providers/Cargo.toml:
  unused dependencies:
    serde

workspace -- crates/workspace/Cargo.toml:
  unused dependencies:
    windows
    dap

worktree -- crates/worktree/Cargo.toml:
  unused dependencies:
    serde
    git2

zed -- crates/zed/Cargo.toml:
  unused dependencies:
    profiling
    dap
    task

zeta -- crates/zeta/Cargo.toml:
  unused dependencies:
    reqwest_client
    call
    rpc
    serde
    tree-sitter-go

zeta2 -- crates/zeta2/Cargo.toml:
  unused dependencies:
    lsp

zeta2_tools -- crates/zeta2_tools/Cargo.toml:
  unused dependencies:
    zlog
    indoc
    clap
    serde
    settings
    pretty_assertions

root -- Cargo.toml:
  unused dependencies:
    pet-pixi
    collab
    wit-component
    num-traits
    storybook
    futures-batch
    plugin_macros
    cocoa-foundation
    ai
    hyper
    scheduler
    auto_update_helper
    plugin
    theme_importer
    rich_text


cargo-shear may have detected unused dependencies incorrectly due to its limitations.
They can be ignored by adding the crate name to the package's Cargo.toml:

[package.metadata.cargo-shear]
ignored = ["crate-name"]

or in the workspace Cargo.toml:

[workspace.metadata.cargo-shear]
ignored = ["crate-name"]

To automatically fix issues, run with --fix
```

</details>