### PR TITLE
chore: release v1.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.6](https://github.com/Boshen/cargo-shear/compare/v1.6.5...v1.6.6) - 2025-11-26
+
+### Fixed
+
+- fix incorrect `--version` output ([#326](https://github.com/Boshen/cargo-shear/pull/326))
+
+### Other
+
+- Fix detection of redundant workspace ignores ([#324](https://github.com/Boshen/cargo-shear/pull/324))
+- Switch from `syn` to `ra_ap_syntax` for parsing ([#322](https://github.com/Boshen/cargo-shear/pull/322))
+
 ## [1.6.5](https://github.com/Boshen/cargo-shear/compare/v1.6.4...v1.6.5) - 2025-11-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.6.5"
+version = "1.6.6"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.6.5 -> 1.6.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.6.6](https://github.com/Boshen/cargo-shear/compare/v1.6.5...v1.6.6) - 2025-11-26

### Fixed

- fix incorrect `--version` output ([#326](https://github.com/Boshen/cargo-shear/pull/326))

### Other

- Fix detection of redundant workspace ignores ([#324](https://github.com/Boshen/cargo-shear/pull/324))
- Switch from `syn` to `ra_ap_syntax` for parsing ([#322](https://github.com/Boshen/cargo-shear/pull/322))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).