### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0](https://github.com/Boshen/cargo-shear/compare/v1.6.6...v1.7.0) - 2025-11-30
+
+### Added
+
+- improve redundant ignore warning messages ([#333](https://github.com/Boshen/cargo-shear/pull/333))
+
+### Other
+
+- Replace `cargo_toml` with custom spanned structs  ([#338](https://github.com/Boshen/cargo-shear/pull/338))
+- Track feature references for dependencies, split out optionals  ([#335](https://github.com/Boshen/cargo-shear/pull/335))
+- Improve tracking of dependencies, and precision of TOML updates ([#334](https://github.com/Boshen/cargo-shear/pull/334))
+- collect import syntax tokens not string ([#328](https://github.com/Boshen/cargo-shear/pull/328))
+- Process packages in parallel using `rayon` ([#329](https://github.com/Boshen/cargo-shear/pull/329))
+- *(deps)* update crate-ci/typos action to v1.40.0 ([#330](https://github.com/Boshen/cargo-shear/pull/330))
+
 ## [1.6.6](https://github.com/Boshen/cargo-shear/compare/v1.6.5...v1.6.6) - 2025-11-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.6.6"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.6.6"
+version = "1.7.0"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.6.6 -> 1.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.7.0](https://github.com/Boshen/cargo-shear/compare/v1.6.6...v1.7.0) - 2025-11-30

### Added

- improve redundant ignore warning messages ([#333](https://github.com/Boshen/cargo-shear/pull/333))

### Other

- Replace `cargo_toml` with custom spanned structs  ([#338](https://github.com/Boshen/cargo-shear/pull/338))
- Track feature references for dependencies, split out optionals  ([#335](https://github.com/Boshen/cargo-shear/pull/335))
- Improve tracking of dependencies, and precision of TOML updates ([#334](https://github.com/Boshen/cargo-shear/pull/334))
- collect import syntax tokens not string ([#328](https://github.com/Boshen/cargo-shear/pull/328))
- Process packages in parallel using `rayon` ([#329](https://github.com/Boshen/cargo-shear/pull/329))
- *(deps)* update crate-ci/typos action to v1.40.0 ([#330](https://github.com/Boshen/cargo-shear/pull/330))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).