### PR TITLE
feat: improve redundant ignore warning messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ impl<W: Write> CargoShear<W> {
         for ignored_dep in &result.redundant_ignores {
             writeln!(
                 self.writer,
-                "warning: '{ignored_dep}' is redundant in [package.metadata.cargo-shear] for package '{}'.\n",
+                "warning: '{ignored_dep}' in [package.metadata.cargo-shear] for package '{}' is ignored but not needed; remove it unless you're suppressing a known false positive.\n",
                 package.name
             )?;
         }
@@ -420,7 +420,7 @@ impl<W: Write> CargoShear<W> {
         for ignored_dep in &result.redundant_ignores {
             writeln!(
                 self.writer,
-                "warning: '{ignored_dep}' is redundant in [workspace.metadata.cargo-shear].\n"
+                "warning: '{ignored_dep}' in [workspace.metadata.cargo-shear] is ignored but not needed; remove it unless you're suppressing a known false positive.\n"
             )?;
         }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -139,7 +139,7 @@ fn ignored_invalid() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    warning: 'anywho' is redundant in [package.metadata.cargo-shear] for package 'ignored_invalid'.
+    warning: 'anywho' in [package.metadata.cargo-shear] for package 'ignored_invalid' is ignored but not needed; remove it unless you're suppressing a known false positive.
 
     No issues detected!
     ");
@@ -156,7 +156,7 @@ fn ignored_redundant() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    warning: 'anyhow' is redundant in [package.metadata.cargo-shear] for package 'ignored_redundant'.
+    warning: 'anyhow' in [package.metadata.cargo-shear] for package 'ignored_redundant' is ignored but not needed; remove it unless you're suppressing a known false positive.
 
     No issues detected!
     ");
@@ -188,7 +188,7 @@ fn ignored_workspace_redundant() -> Result<(), Box<dyn Error>> {
     insta::assert_snapshot!(output, @r"
     Analyzing .
 
-    warning: 'anyhow' is redundant in [workspace.metadata.cargo-shear].
+    warning: 'anyhow' in [workspace.metadata.cargo-shear] is ignored but not needed; remove it unless you're suppressing a known false positive.
 
     No issues detected!
     ");


### PR DESCRIPTION
Clarify redundant-ignore warnings to explain the entry isn't needed unless suppressing a known false positive. 

## Fix
https://github.com/Boshen/cargo-shear/issues/321

## Summary

Updates warning messages for redundant ignores in both package and workspace metadata sections. The new messages provide clearer guidance by explicitly stating that ignored dependencies are not needed and can be safely removed unless the user is intentionally suppressing a known false positive.

## Changes

- Updated warning message format in `report_package_issues()` for package-level redundant ignores
- Updated warning message format in `report_workspace_issues()` for workspace-level redundant ignores
- Updated integration test snapshots to match the new warning text

## Files Touched

- `src/lib.rs`
- `tests/integration_tests.rs`