### PR TITLE
chore: release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1](https://github.com/Boshen/cargo-shear/compare/v1.7.0...v1.7.1) - 2025-12-03
+
+### <!-- 9 -->💼 Other
+- Skip workspace analysis when package/exclude is specified ([#343](https://github.com/Boshen/cargo-shear/pull/343)) (by @CathalMullan)
+- Switch to `miette` for output, add new warnings ([#342](https://github.com/Boshen/cargo-shear/pull/342)) (by @CathalMullan)
+
+### Contributors
+
+* @CathalMullan
+* @renovate[bot]
+* @Boshen
+
 ## [1.7.0](https://github.com/Boshen/cargo-shear/compare/v1.6.6...v1.7.0) - 2025-11-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.7.0 -> 1.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.7.1](https://github.com/Boshen/cargo-shear/compare/v1.7.0...v1.7.1) - 2025-12-03

### <!-- 9 -->💼 Other
- Skip workspace analysis when package/exclude is specified ([#343](https://github.com/Boshen/cargo-shear/pull/343)) (by @CathalMullan)
- Switch to `miette` for output, add new warnings ([#342](https://github.com/Boshen/cargo-shear/pull/342)) (by @CathalMullan)

### Contributors

* @CathalMullan
* @renovate[bot]
* @Boshen
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).