### PR TITLE
Switch to `miette` for output, add new warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "cfg_aliases",
 ]
@@ -76,7 +76,9 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "insta",
+ "miette",
  "mimalloc-safe",
+ "owo-colors",
  "ra_ap_syntax",
  "rayon",
  "rustc-hash 2.1.1",
@@ -113,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -286,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,9 +316,9 @@ checksum = "a037eddb7d28de1d0fc42411f501b53b75838d313908078d6698d064f3029b24"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libmimalloc-sys2"
@@ -345,6 +353,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "mimalloc-safe"
 version = "0.1.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +391,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "pin-project-lite"
@@ -400,9 +430,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ra-ap-rustc_lexer"
-version = "0.137.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac80365383a3c749f38af567fdcfaeff3fa6ea5df3846852abbce73e943921b9"
+checksum = "5ec7c26e92c44d5433b29cf661faf0027e263b70a411d0f28996bd67e3bdb57e"
 dependencies = [
  "memchr",
  "unicode-properties",
@@ -411,15 +441,15 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_edition"
-version = "0.0.307"
+version = "0.0.308"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827b826e17647842049aa07bb4f75d78516ddcb32d651307de6b2891d9349396"
+checksum = "b524def5f406cc8a58ed9c6090d55f76fe940ebcb42fbd02da25c6515c0c5551"
 
 [[package]]
 name = "ra_ap_parser"
-version = "0.0.307"
+version = "0.0.308"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2876e07c278c85cb458f0fe1a9679a48d561a95868e67b465fb328458506867"
+checksum = "8acc1856cd65b7b24319e739991fd73886037695a1a71ba2223cc20578408508"
 dependencies = [
  "drop_bomb",
  "ra-ap-rustc_lexer",
@@ -431,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_stdx"
-version = "0.0.307"
+version = "0.0.308"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd94073132b765585a905d68352e5a9a0513d66e0da7186892cebc033fd347ee"
+checksum = "c6ffc0b6d8ad9d8e22357275c6c3dda98c6368a769b00207abcebbf1687f4b99"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
@@ -447,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "ra_ap_syntax"
-version = "0.0.307"
+version = "0.0.308"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d3d6c19beb665511d026e513134b053282ec38e45d74f6a7a8287f79de90bc"
+checksum = "c6191e4d29d8ed1699bcfc227c74bfe6a47bc8d76d81dc2768478a2340971e13"
 dependencies = [
  "either",
  "itertools",
@@ -485,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.15.15"
+version = "0.15.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
+checksum = "d4f1e4a001f863f41ea8d0e6a0c34b356d5b733db50dadab3efef640bafb779b"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
@@ -627,6 +657,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,10 +702,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -730,9 +801,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -740,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
@@ -760,10 +831,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -963,9 +1052,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,17 @@ test = false
 walkdir = "2.5.0"
 cargo_metadata = "0.23.0"
 bpaf = { version = "0.9.19", features = ["derive", "batteries"] }
-ra_ap_syntax = "0.0.307"
+ra_ap_syntax = "0.0.308"
 rayon = "1.10.0"
 serde = { version = "1.0.228", features = ["derive"] }
 toml = { version = "0.9.8", features = ["serde"] }
 toml_edit = { version = "0.23.0", features = ["parse"] }
 anyhow = "1.0.97"
 rustc-hash = "2.1.1"
+miette = { version = "7.6", default-features = false, features = [
+  "fancy-no-backtrace",
+] }
+owo-colors = "4.2.3"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,448 @@
+use std::{error::Error, fmt, path::Path};
+
+use miette::{Diagnostic, LabeledSpan, NamedSource, Severity, SourceSpan};
+use rustc_hash::FxHashSet;
+
+use crate::{
+    dependency_analyzer::FeatureRef,
+    manifest::DepTable,
+    package_processor::{
+        MisplacedDependency, MisplacedOptionalDependency, PackageAnalysis, RedundantIgnore,
+        UnknownIgnore, UnusedDependency, UnusedFeatureDependency, UnusedOptionalDependency,
+        UnusedWorkspaceDependency, WorkspaceAnalysis,
+    },
+};
+
+/// Result of processing all packages across the workspace.
+#[derive(Debug, Default)]
+pub struct ShearAnalysis {
+    /// All diagnostic findings.
+    pub findings: Vec<ShearDiagnostic>,
+
+    /// All package names used across the workspace.
+    pub packages: FxHashSet<String>,
+
+    /// Count of unused dependencies.
+    pub unused: usize,
+
+    /// Count of misplaced dependencies.
+    pub misplaced: usize,
+
+    /// Count of warnings.
+    /// Anything that can't be automatically fixed is considered a warning.
+    pub warnings: usize,
+
+    /// Count of dependencies that were fixed (removed or moved).
+    pub fixed: usize,
+}
+
+impl ShearAnalysis {
+    pub fn add_package_result(
+        &mut self,
+        path: &Path,
+        content: String,
+        result: &PackageAnalysis,
+        fixed: usize,
+    ) {
+        let src = NamedSource::new(path.display().to_string(), content);
+        self.packages.extend(result.used_packages.iter().cloned());
+        self.fixed += fixed;
+
+        for finding in &result.unused_dependencies {
+            self.insert(ShearDiagnostic::unused_dependency(finding, &src));
+        }
+
+        for finding in &result.unused_optional_dependencies {
+            self.insert(ShearDiagnostic::unused_optional_dependency(finding, &src));
+        }
+
+        for finding in &result.unused_feature_dependencies {
+            self.insert(ShearDiagnostic::unused_feature_dependency(finding, &src));
+        }
+
+        for finding in &result.misplaced_dependencies {
+            self.insert(ShearDiagnostic::misplaced_dependency(finding, &src));
+        }
+
+        for finding in &result.misplaced_optional_dependencies {
+            self.insert(ShearDiagnostic::misplaced_optional_dependency(finding, &src));
+        }
+
+        for finding in &result.unknown_ignores {
+            self.insert(ShearDiagnostic::unknown_ignore(finding, &src));
+        }
+
+        for finding in &result.redundant_ignores {
+            self.insert(ShearDiagnostic::redundant_ignore(finding, &src));
+        }
+    }
+
+    pub fn add_workspace_result(
+        &mut self,
+        path: &Path,
+        content: String,
+        result: &WorkspaceAnalysis,
+        fixed: usize,
+    ) {
+        let src = NamedSource::new(path.display().to_string(), content);
+        self.fixed += fixed;
+
+        for finding in &result.unused_dependencies {
+            self.insert(ShearDiagnostic::unused_workspace_dependency(finding, &src));
+        }
+
+        for finding in &result.unknown_ignores {
+            self.insert(ShearDiagnostic::unknown_ignore(finding, &src));
+        }
+
+        for finding in &result.redundant_ignores {
+            self.insert(ShearDiagnostic::redundant_ignore(finding, &src));
+        }
+    }
+
+    fn insert(&mut self, diagnostic: ShearDiagnostic) {
+        match &diagnostic.kind {
+            DiagnosticKind::UnusedDependency { .. }
+            | DiagnosticKind::UnusedWorkspaceDependency { .. } => self.unused += 1,
+            DiagnosticKind::MisplacedDependency { .. } => self.misplaced += 1,
+            DiagnosticKind::UnusedOptionalDependency { .. }
+            | DiagnosticKind::UnusedFeatureDependency { .. }
+            | DiagnosticKind::MisplacedOptionalDependency { .. }
+            | DiagnosticKind::UnknownIgnore { .. }
+            | DiagnosticKind::RedundantIgnore { .. } => self.warnings += 1,
+        }
+
+        self.findings.push(diagnostic);
+    }
+}
+
+/// Unified diagnostic type that contains all information needed for display.
+pub struct ShearDiagnostic {
+    /// The kind of diagnostic.
+    kind: DiagnosticKind,
+
+    /// Source content.
+    source: NamedSource<String>,
+
+    /// Primary span.
+    span: SourceSpan,
+
+    /// Any related diagnostics.
+    related: Vec<Box<dyn Diagnostic + Send + Sync>>,
+
+    /// Optional help text.
+    help: Option<String>,
+}
+
+impl fmt::Debug for ShearDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ShearDiagnostic")
+            .field("kind", &self.kind)
+            .field("source", &self.source)
+            .field("span", &self.span)
+            .field("related", &format!("[{} related diagnostics]", self.related.len()))
+            .field("help", &self.help)
+            .finish()
+    }
+}
+
+impl ShearDiagnostic {
+    pub fn unused_dependency(diagnostic: &UnusedDependency, source: &NamedSource<String>) -> Self {
+        Self {
+            kind: DiagnosticKind::UnusedDependency { name: diagnostic.name.get_ref().clone() },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: Vec::new(),
+            help: Some("remove this dependency".to_owned()),
+        }
+    }
+
+    pub fn unused_workspace_dependency(
+        diagnostic: &UnusedWorkspaceDependency,
+        source: &NamedSource<String>,
+    ) -> Self {
+        Self {
+            kind: DiagnosticKind::UnusedWorkspaceDependency {
+                name: diagnostic.name.get_ref().clone(),
+            },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: Vec::new(),
+            help: Some("remove this dependency".to_owned()),
+        }
+    }
+
+    pub fn unused_optional_dependency(
+        diagnostic: &UnusedOptionalDependency,
+        source: &NamedSource<String>,
+    ) -> Self {
+        Self {
+            kind: DiagnosticKind::UnusedOptionalDependency {
+                name: diagnostic.name.get_ref().clone(),
+            },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: ShearRelatedDiagnostic::from_features(
+                Some("removing an optional dependency may be a breaking change"),
+                &diagnostic.features,
+                source,
+            ),
+            help: None,
+        }
+    }
+
+    pub fn unused_feature_dependency(
+        diagnostic: &UnusedFeatureDependency,
+        source: &NamedSource<String>,
+    ) -> Self {
+        Self {
+            kind: DiagnosticKind::UnusedFeatureDependency {
+                name: diagnostic.name.get_ref().clone(),
+            },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: ShearRelatedDiagnostic::from_features(None, &diagnostic.features, source),
+            help: None,
+        }
+    }
+
+    pub fn misplaced_dependency(
+        diagnostic: &MisplacedDependency,
+        source: &NamedSource<String>,
+    ) -> Self {
+        let target = diagnostic.location.as_table(DepTable::Dev);
+        Self {
+            kind: DiagnosticKind::MisplacedDependency { name: diagnostic.name.get_ref().clone() },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: Vec::new(),
+            help: Some(format!("move this dependency to `{target}`")),
+        }
+    }
+
+    pub fn misplaced_optional_dependency(
+        diagnostic: &MisplacedOptionalDependency,
+        source: &NamedSource<String>,
+    ) -> Self {
+        let target = diagnostic.location.as_table(DepTable::Dev);
+        Self {
+            kind: DiagnosticKind::MisplacedOptionalDependency {
+                name: diagnostic.name.get_ref().clone(),
+            },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: ShearRelatedDiagnostic::from_features(
+                Some("removing an optional dependency may be a breaking change"),
+                &diagnostic.features,
+                source,
+            ),
+            help: Some(format!("remove the `optional` flag and move to `{target}`")),
+        }
+    }
+
+    pub fn unknown_ignore(diagnostic: &UnknownIgnore, source: &NamedSource<String>) -> Self {
+        Self {
+            kind: DiagnosticKind::UnknownIgnore { name: diagnostic.name.get_ref().clone() },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: Vec::new(),
+            help: Some("remove from ignored list".to_owned()),
+        }
+    }
+
+    pub fn redundant_ignore(diagnostic: &RedundantIgnore, source: &NamedSource<String>) -> Self {
+        Self {
+            kind: DiagnosticKind::RedundantIgnore { name: diagnostic.name.get_ref().clone() },
+            source: source.clone(),
+            span: diagnostic.name.span().into(),
+            related: Vec::new(),
+            help: Some("remove from ignored list".to_owned()),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum DiagnosticKind {
+    UnusedDependency { name: String },
+    UnusedWorkspaceDependency { name: String },
+    UnusedOptionalDependency { name: String },
+    UnusedFeatureDependency { name: String },
+    MisplacedDependency { name: String },
+    MisplacedOptionalDependency { name: String },
+    UnknownIgnore { name: String },
+    RedundantIgnore { name: String },
+}
+
+impl DiagnosticKind {
+    fn message(&self) -> String {
+        match self {
+            Self::UnusedDependency { name } => format!("unused dependency `{name}`"),
+            Self::UnusedWorkspaceDependency { name } => {
+                format!("unused workspace dependency `{name}`")
+            }
+            Self::UnusedOptionalDependency { name } => {
+                format!("unused optional dependency `{name}`")
+            }
+            Self::UnusedFeatureDependency { name } => {
+                format!("dependency `{name}` only used in features")
+            }
+            Self::MisplacedDependency { name } => format!("misplaced dependency `{name}`"),
+            Self::MisplacedOptionalDependency { name } => {
+                format!("misplaced optional dependency `{name}`")
+            }
+            Self::UnknownIgnore { name } => format!("unknown ignore `{name}`"),
+            Self::RedundantIgnore { name } => format!("redundant ignore `{name}`"),
+        }
+    }
+
+    const fn label(&self) -> &'static str {
+        match self {
+            Self::UnusedWorkspaceDependency { .. } => "not used by any workspace member",
+            Self::UnusedDependency { .. }
+            | Self::UnusedOptionalDependency { .. }
+            | Self::UnusedFeatureDependency { .. } => "not used in code",
+            Self::MisplacedDependency { .. } | Self::MisplacedOptionalDependency { .. } => {
+                "only used in dev targets"
+            }
+            Self::UnknownIgnore { .. } => "not a dependency",
+            Self::RedundantIgnore { .. } => "dependency is used",
+        }
+    }
+
+    const fn code(&self) -> &'static str {
+        match self {
+            Self::UnusedDependency { .. } => "shear/unused_dependency",
+            Self::UnusedWorkspaceDependency { .. } => "shear/unused_workspace_dependency",
+            Self::UnusedOptionalDependency { .. } => "shear/unused_optional_dependency",
+            Self::UnusedFeatureDependency { .. } => "shear/unused_feature_dependency",
+            Self::MisplacedDependency { .. } => "shear/misplaced_dependency",
+            Self::MisplacedOptionalDependency { .. } => "shear/misplaced_optional_dependency",
+            Self::UnknownIgnore { .. } => "shear/unknown_ignore",
+            Self::RedundantIgnore { .. } => "shear/redundant_ignore",
+        }
+    }
+
+    const fn severity(&self) -> Severity {
+        match self {
+            Self::UnusedDependency { .. }
+            | Self::UnusedWorkspaceDependency { .. }
+            | Self::MisplacedDependency { .. } => Severity::Error,
+            Self::UnusedOptionalDependency { .. }
+            | Self::UnusedFeatureDependency { .. }
+            | Self::MisplacedOptionalDependency { .. }
+            | Self::UnknownIgnore { .. }
+            | Self::RedundantIgnore { .. } => Severity::Warning,
+        }
+    }
+}
+
+impl fmt::Display for ShearDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind.message())
+    }
+}
+
+impl Error for ShearDiagnostic {}
+
+impl Diagnostic for ShearDiagnostic {
+    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        Some(Box::new(self.kind.code()))
+    }
+
+    fn severity(&self) -> Option<Severity> {
+        Some(self.kind.severity())
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        self.help.as_ref().map(|help| Box::new(help.as_str()) as Box<dyn fmt::Display>)
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(LabeledSpan::new_with_span(
+            Some(self.kind.label().to_owned()),
+            self.span,
+        ))))
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        if self.related.is_empty() {
+            return None;
+        }
+
+        Some(Box::new(self.related.iter().map(|diagnostic| diagnostic.as_ref() as &dyn Diagnostic)))
+    }
+}
+
+/// A related diagnostic.
+#[derive(Debug)]
+struct ShearRelatedDiagnostic {
+    message: String,
+    label: Option<(String, SourceSpan, NamedSource<String>)>,
+}
+
+impl ShearRelatedDiagnostic {
+    fn from_features(
+        message: Option<&str>,
+        features: &[FeatureRef],
+        source: &NamedSource<String>,
+    ) -> Vec<Box<dyn Diagnostic + Send + Sync>> {
+        let mut related: Vec<Box<dyn Diagnostic + Send + Sync>> = Vec::new();
+
+        if let Some(message) = message {
+            related.push(Self { message: message.to_owned(), label: None }.into());
+        }
+
+        for feature in features {
+            match feature {
+                FeatureRef::Explicit { feature, value }
+                | FeatureRef::DepFeature { feature, value }
+                | FeatureRef::WeakDepFeature { feature, value } => {
+                    let name = feature.get_ref();
+                    related.push(
+                        Self {
+                            message: format!("used in feature `{name}`"),
+                            label: Some((
+                                "enabled here".to_owned(),
+                                value.span().into(),
+                                source.clone(),
+                            )),
+                        }
+                        .into(),
+                    );
+                }
+                FeatureRef::Implicit => {}
+            }
+        }
+
+        related
+    }
+}
+
+impl fmt::Display for ShearRelatedDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for ShearRelatedDiagnostic {}
+
+impl Diagnostic for ShearRelatedDiagnostic {
+    fn severity(&self) -> Option<Severity> {
+        Some(Severity::Advice)
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        self.label.as_ref().map(|(_, _, source)| source as &dyn miette::SourceCode)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.label.as_ref().map(|(label, span, _)| {
+            Box::new(std::iter::once(LabeledSpan::new_with_span(Some(label.clone()), *span)))
+                as Box<dyn Iterator<Item = LabeledSpan> + '_>
+        })
+    }
+}

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -34,6 +34,15 @@ impl DepLocation {
     pub const fn is_normal(&self) -> bool {
         matches!(self, Self::Root(DepTable::Normal) | Self::Target { table: DepTable::Normal, .. })
     }
+
+    /// Move this location to a different table.
+    #[must_use]
+    pub fn as_table(&self, new: DepTable) -> Self {
+        match self {
+            Self::Root(_) => Self::Root(new),
+            Self::Target { cfg, .. } => Self::Target { cfg: cfg.clone(), table: new },
+        }
+    }
 }
 
 impl fmt::Display for DepLocation {
@@ -48,7 +57,7 @@ impl fmt::Display for DepLocation {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub enum Dependency {
-    #[expect(unused, reason = "TODO")]
+    #[expect(unused, reason = "Needed for deserialization")]
     Simple(String),
     Detailed(DependencyDetail),
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,90 @@
+use std::{io, io::IsTerminal, str::FromStr};
+
+use crate::{diagnostics::ShearAnalysis, output::miette::MietteRenderer};
+
+pub mod miette;
+
+/// Output format for cargo-shear.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum OutputFormat {
+    /// Auto format with colors and unicode.
+    #[default]
+    Auto,
+}
+
+impl FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            _ => Err(format!("unknown format: {s}, expected: auto")),
+        }
+    }
+}
+
+/// Color mode for output.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ColorMode {
+    /// Automatically detect based on environment.
+    #[default]
+    Auto,
+
+    /// Always use colors.
+    Always,
+
+    /// Never use colors.
+    Never,
+}
+
+impl ColorMode {
+    /// Whether to show color.
+    #[must_use]
+    pub fn enabled(self) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::Auto => {
+                if std::env::var_os("NO_COLOR").is_some() {
+                    return false;
+                }
+
+                std::io::stdout().is_terminal()
+            }
+        }
+    }
+}
+
+impl FromStr for ColorMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "always" => Ok(Self::Always),
+            "never" => Ok(Self::Never),
+            _ => Err(format!("unknown color option: {s}, expected one of: auto, always, never")),
+        }
+    }
+}
+
+pub struct Renderer<W> {
+    writer: W,
+    format: OutputFormat,
+    color: bool,
+}
+
+impl<W: io::Write> Renderer<W> {
+    pub const fn new(writer: W, format: OutputFormat, color: bool) -> Self {
+        Self { writer, format, color }
+    }
+
+    pub fn render(&mut self, analysis: &ShearAnalysis) -> io::Result<()> {
+        match self.format {
+            OutputFormat::Auto => {
+                let mut renderer = MietteRenderer::new(&mut self.writer, self.color);
+                renderer.render(analysis)
+            }
+        }
+    }
+}

--- a/src/output/miette.rs
+++ b/src/output/miette.rs
@@ -1,0 +1,199 @@
+use std::{error::Error, fmt, io};
+
+use miette::{
+    Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, NamedSource, Severity,
+};
+use owo_colors::OwoColorize;
+
+use crate::diagnostics::ShearAnalysis;
+
+/// A renderer using `miette`.
+pub struct MietteRenderer<W> {
+    writer: W,
+    color: bool,
+}
+
+impl<W: io::Write> MietteRenderer<W> {
+    pub const fn new(writer: W, color: bool) -> Self {
+        Self { writer, color }
+    }
+
+    pub fn render(&mut self, analysis: &ShearAnalysis) -> io::Result<()> {
+        let theme =
+            if self.color { GraphicalTheme::unicode() } else { GraphicalTheme::unicode_nocolor() };
+
+        let handler = GraphicalReportHandler::new_themed(theme.clone());
+        let mut output = String::new();
+
+        // Print all diagnostics
+        for diagnostic in &analysis.findings {
+            output.clear();
+            handler.render_report(&mut output, diagnostic).map_err(io::Error::other)?;
+            writeln!(self.writer, "{output}")?;
+        }
+
+        // Print summary
+        writeln!(self.writer, "{}", "shear/summary".style(theme.styles.advice))?;
+        writeln!(self.writer)?;
+
+        if analysis.findings.is_empty() && analysis.fixed == 0 {
+            writeln!(self.writer, "  {} no issues found", "✓".style(theme.styles.advice))?;
+            return Ok(());
+        }
+
+        if analysis.findings.is_empty() && analysis.fixed > 0 {
+            writeln!(
+                self.writer,
+                "  {} {} issue{} fixed",
+                "✓".style(theme.styles.advice),
+                analysis.fixed,
+                if analysis.fixed == 1 { "" } else { "s" }
+            )?;
+
+            return Ok(());
+        }
+
+        // Print stats
+        let errors = analysis.unused + analysis.misplaced;
+        if errors > 0 {
+            writeln!(
+                self.writer,
+                "  {} {} error{}",
+                "✗".style(theme.styles.error),
+                errors,
+                if errors == 1 { "" } else { "s" }
+            )?;
+        }
+
+        if analysis.warnings > 0 {
+            writeln!(
+                self.writer,
+                "  {} {} warning{}",
+                "⚠".style(theme.styles.warning),
+                analysis.warnings,
+                if analysis.warnings == 1 { "" } else { "s" }
+            )?;
+        }
+
+        if analysis.fixed > 0 {
+            writeln!(
+                self.writer,
+                "  {} {} issue{} fixed",
+                "⚒".style(theme.styles.advice),
+                analysis.fixed,
+                if analysis.fixed == 1 { "" } else { "s" }
+            )?;
+        }
+
+        writeln!(self.writer)?;
+        writeln!(self.writer, "Advice:")?;
+
+        if errors > 0 && analysis.fixed == 0 {
+            writeln!(
+                self.writer,
+                "  {} run with `--fix` to fix {} issue{}",
+                "☞".style(theme.styles.advice),
+                errors,
+                if errors == 1 { "" } else { "s" }
+            )?;
+        }
+
+        output.clear();
+        handler
+            .render_report(&mut output, &PackageIgnoreHelpDiagnostic::new())
+            .map_err(io::Error::other)?;
+
+        write!(self.writer, "{output}")?;
+
+        output.clear();
+        handler
+            .render_report(&mut output, &WorkspaceIgnoreHelpDiagnostic::new())
+            .map_err(io::Error::other)?;
+
+        write!(self.writer, "{output}")?;
+
+        Ok(())
+    }
+}
+
+/// A diagnostic that displays help for ignoring issues at package level.
+struct PackageIgnoreHelpDiagnostic {
+    source: NamedSource<&'static str>,
+}
+
+impl PackageIgnoreHelpDiagnostic {
+    const SOURCE: &str = "[package.metadata.cargo-shear]\nignored = [\"crate-name\"]";
+
+    fn new() -> Self {
+        Self { source: NamedSource::new("Cargo.toml", Self::SOURCE) }
+    }
+}
+
+impl fmt::Debug for PackageIgnoreHelpDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PackageIgnoreHelpDiagnostic").finish()
+    }
+}
+
+impl fmt::Display for PackageIgnoreHelpDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "to suppress an issue within a package")
+    }
+}
+
+impl Error for PackageIgnoreHelpDiagnostic {}
+
+impl Diagnostic for PackageIgnoreHelpDiagnostic {
+    fn severity(&self) -> Option<Severity> {
+        Some(Severity::Advice)
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(LabeledSpan::at(42..54, "add the crate name here"))))
+    }
+}
+
+/// A diagnostic that displays help for ignoring issues at workspace level.
+struct WorkspaceIgnoreHelpDiagnostic {
+    source: NamedSource<&'static str>,
+}
+
+impl WorkspaceIgnoreHelpDiagnostic {
+    const SOURCE: &str = "[workspace.metadata.cargo-shear]\nignored = [\"crate-name\"]";
+
+    fn new() -> Self {
+        Self { source: NamedSource::new("Cargo.toml", Self::SOURCE) }
+    }
+}
+
+impl fmt::Debug for WorkspaceIgnoreHelpDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WorkspaceIgnoreHelpDiagnostic").finish()
+    }
+}
+
+impl fmt::Display for WorkspaceIgnoreHelpDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "to suppress an issue across a workspace")
+    }
+}
+
+impl Error for WorkspaceIgnoreHelpDiagnostic {}
+
+impl Diagnostic for WorkspaceIgnoreHelpDiagnostic {
+    fn severity(&self) -> Option<Severity> {
+        Some(Severity::Advice)
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(std::iter::once(LabeledSpan::at(44..56, "add the crate name here"))))
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,11 @@ use std::{fmt::Write, process::ExitCode};
 
 use rustc_hash::FxHashSet;
 
-use crate::{CargoShear, CargoShearOptions, default_path, import_collector::collect_imports};
+use crate::{
+    CargoShear, CargoShearOptions, default_path,
+    import_collector::collect_imports,
+    output::{ColorMode, OutputFormat},
+};
 
 #[track_caller]
 fn test(source_text: &str) {
@@ -90,6 +94,8 @@ fn test_lib() {
             exclude: vec![],
             path: default_path().unwrap(),
             expand: false,
+            format: OutputFormat::Auto,
+            color: ColorMode::Never,
         },
     );
     let exit_code = shear.run();
@@ -311,6 +317,8 @@ fn cargo_shear_with_different_options() {
             exclude: vec![],
             path: default_path().unwrap(),
             expand: false,
+            format: OutputFormat::Auto,
+            color: ColorMode::Never,
         },
     );
     let exit_code = shear.run();
@@ -331,6 +339,8 @@ fn cargo_shear_with_package_filter() {
             exclude: vec![],
             path: default_path().unwrap(),
             expand: false,
+            format: OutputFormat::Auto,
+            color: ColorMode::Never,
         },
     );
     let exit_code = shear.run();
@@ -351,6 +361,8 @@ fn cargo_shear_with_exclude_filter() {
             exclude: vec!["some-package".to_owned()],
             path: default_path().unwrap(),
             expand: false,
+            format: OutputFormat::Auto,
+            color: ColorMode::Never,
         },
     );
     let exit_code = shear.run();
@@ -369,6 +381,8 @@ fn cargo_shear_options_creation() {
         exclude: vec!["exclude1".to_owned()],
         path: std::path::PathBuf::from("/tmp"),
         expand: true,
+        format: OutputFormat::Auto,
+        color: ColorMode::Never,
     };
 
     let shear = CargoShear::new(std::io::sink(), options.clone());
@@ -530,6 +544,8 @@ fn test_cargo_shear_new() {
         exclude: vec![],
         path: default_path().unwrap(),
         expand: false,
+        format: OutputFormat::Auto,
+        color: ColorMode::Never,
     };
     let _shear = CargoShear::new(std::io::sink(), options);
     // Just verify it can be created without panicking

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -61,9 +61,9 @@ fn clean_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
     insta::assert_snapshot!(output, @r"
-    Analyzing .
+    shear/summary
 
-    No issues detected!
+      ✓ no issues found
     ");
 
     Ok(())
@@ -91,9 +91,9 @@ fn clean_workspace_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
     insta::assert_snapshot!(output, @r"
-    Analyzing .
+    shear/summary
 
-    No issues detected!
+      ✓ no issues found
     ");
 
     Ok(())
@@ -117,42 +117,298 @@ fn clean_workspace_fix() -> Result<(), Box<dyn Error>> {
 
 // Complex fixture with one of each issue type of issue.
 #[test]
+#[expect(clippy::too_many_lines, reason = "Output stress test")]
 fn complex_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("complex", false)?;
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    warning: 'slab' in [package.metadata.cargo-shear] for package 'complex' is ignored but not needed; remove it unless you're suppressing a known false positive.
+      × unused dependency `bitflags_v2`
+        ╭─[Cargo.toml:28:1]
+     27 │ # Unused Renamed
+     28 │ bitflags_v2 = { package = "bitflags", version = "2.0" }
+        · ─────┬─────
+        ·      ╰── not used in code
+     29 │ 
+        ╰────
+      help: remove this dependency
 
-    warning: 'fake-crate' in [package.metadata.cargo-shear] for package 'complex' is ignored but not needed; remove it unless you're suppressing a known false positive.
+    shear/unused_dependency
 
-    complex -- Cargo.toml:
-      unused dependencies:
-        either
-        serde
-        bitflags_v2
-        winapi
-        cfg-if
-        version_check
-      move to dev-dependencies:
-        ryu_v1
-        fastrand
+      × unused dependency `cfg-if`
+        ╭─[Cargo.toml:64:15]
+     63 │ # Unused Table
+     64 │ [dependencies.cfg-if]
+        ·               ───┬──
+        ·                  ╰── not used in code
+     65 │ version = "1.0"
+        ╰────
+      help: remove this dependency
 
+    shear/unused_dependency
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      × unused dependency `either`
+        ╭─[Cargo.toml:16:1]
+     15 │ # Unused
+     16 │ either = "1.0"
+        · ───┬──
+        ·    ╰── not used in code
+     17 │ 
+        ╰────
+      help: remove this dependency
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
+    shear/unused_dependency
 
-    or in the workspace Cargo.toml:
+      × unused dependency `serde`
+        ╭─[Cargo.toml:53:1]
+     52 │ # Unused Dev
+     53 │ serde = "1.0"
+        · ──┬──
+        ·   ╰── not used in code
+     54 │ 
+        ╰────
+      help: remove this dependency
 
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
+    shear/unused_dependency
 
-    To automatically fix issues, run with --fix
+      × unused dependency `version_check`
+        ╭─[Cargo.toml:57:1]
+     56 │ # Unused Build
+     57 │ version_check = "0.9"
+        · ──────┬──────
+        ·       ╰── not used in code
+     58 │ 
+        ╰────
+      help: remove this dependency
+
+    shear/unused_dependency
+
+      × unused dependency `winapi`
+        ╭─[Cargo.toml:61:1]
+     60 │ # Unused Platform
+     61 │ winapi = "0.3"
+        · ───┬──
+        ·    ╰── not used in code
+     62 │ 
+        ╰────
+      help: remove this dependency
+
+    shear/unused_optional_dependency
+
+      ⚠ unused optional dependency `itoa`
+        ╭─[Cargo.toml:19:1]
+     18 │ # Unused Optional
+     19 │ itoa = { version = "1.0", optional = true }
+        · ──┬─
+        ·   ╰── not used in code
+     20 │ 
+        ╰────
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `unused-optional`
+       ╭─[Cargo.toml:7:20]
+     6 │ [features]
+     7 │ unused-optional = ["dep:itoa"]
+       ·                    ─────┬────
+       ·                         ╰── enabled here
+     8 │ unused-optional-feature = ["once_cell/std"]
+       ╰────
+
+    shear/unused_optional_dependency
+
+      ⚠ unused optional dependency `memchr`
+        ╭─[Cargo.toml:25:1]
+     24 │ # Unused Optional Feature Weak
+     25 │ memchr = { version = "2.7", optional = true }
+        · ───┬──
+        ·    ╰── not used in code
+     26 │ 
+        ╰────
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `unused-optional-weak`
+        ╭─[Cargo.toml:9:25]
+      8 │ unused-optional-feature = ["once_cell/std"]
+      9 │ unused-optional-weak = ["memchr?/std"]
+        ·                         ──────┬──────
+        ·                               ╰── enabled here
+     10 │ misplaced-optional = ["dep:smallvec"]
+        ╰────
+
+    shear/unused_optional_dependency
+
+      ⚠ unused optional dependency `once_cell`
+        ╭─[Cargo.toml:22:1]
+     21 │ # Unused Optional Feature
+     22 │ once_cell = { version = "1.0", optional = true }
+        · ────┬────
+        ·     ╰── not used in code
+     23 │ 
+        ╰────
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `unused-optional-feature`
+       ╭─[Cargo.toml:8:28]
+     7 │ unused-optional = ["dep:itoa"]
+     8 │ unused-optional-feature = ["once_cell/std"]
+       ·                            ───────┬───────
+       ·                                   ╰── enabled here
+     9 │ unused-optional-weak = ["memchr?/std"]
+       ╰────
+
+    shear/misplaced_dependency
+
+      × misplaced dependency `fastrand`
+        ╭─[Cargo.toml:34:1]
+     33 │ # Misplaced
+     34 │ fastrand = "2.0"
+        · ────┬───
+        ·     ╰── only used in dev targets
+     35 │ 
+        ╰────
+      help: move this dependency to `[dev-dependencies]`
+
+    shear/misplaced_dependency
+
+      × misplaced dependency `ryu_v1`
+        ╭─[Cargo.toml:46:1]
+     45 │ # Misplaced Renamed
+     46 │ ryu_v1 = { package = "ryu", version = "1.0" }
+        · ───┬──
+        ·    ╰── only used in dev targets
+     47 │ 
+        ╰────
+      help: move this dependency to `[dev-dependencies]`
+
+    shear/misplaced_optional_dependency
+
+      ⚠ misplaced optional dependency `ahash`
+        ╭─[Cargo.toml:43:1]
+     42 │ # Misplaced Optional Feature Weak
+     43 │ ahash = { version = "0.8", optional = true }
+        · ──┬──
+        ·   ╰── only used in dev targets
+     44 │ 
+        ╰────
+      help: remove the `optional` flag and move to `[dev-dependencies]`
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `misplaced-optional-weak`
+        ╭─[Cargo.toml:12:28]
+     11 │ misplaced-optional-feature = ["hashbrown/serde"]
+     12 │ misplaced-optional-weak = ["ahash?/std"]
+        ·                            ──────┬─────
+        ·                                  ╰── enabled here
+     13 │ 
+        ╰────
+
+    shear/misplaced_optional_dependency
+
+      ⚠ misplaced optional dependency `hashbrown`
+        ╭─[Cargo.toml:40:1]
+     39 │ # Misplaced Optional Feature
+     40 │ hashbrown = { version = "0.15", optional = true }
+        · ────┬────
+        ·     ╰── only used in dev targets
+     41 │ 
+        ╰────
+      help: remove the `optional` flag and move to `[dev-dependencies]`
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `misplaced-optional-feature`
+        ╭─[Cargo.toml:11:31]
+     10 │ misplaced-optional = ["dep:smallvec"]
+     11 │ misplaced-optional-feature = ["hashbrown/serde"]
+        ·                               ────────┬────────
+        ·                                       ╰── enabled here
+     12 │ misplaced-optional-weak = ["ahash?/std"]
+        ╰────
+
+    shear/misplaced_optional_dependency
+
+      ⚠ misplaced optional dependency `smallvec`
+        ╭─[Cargo.toml:37:1]
+     36 │ # Misplaced Optional
+     37 │ smallvec = { version = "1.0", optional = true }
+        · ────┬───
+        ·     ╰── only used in dev targets
+     38 │ 
+        ╰────
+      help: remove the `optional` flag and move to `[dev-dependencies]`
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `misplaced-optional`
+        ╭─[Cargo.toml:10:23]
+      9 │ unused-optional-weak = ["memchr?/std"]
+     10 │ misplaced-optional = ["dep:smallvec"]
+        ·                       ───────┬──────
+        ·                              ╰── enabled here
+     11 │ misplaced-optional-feature = ["hashbrown/serde"]
+        ╰────
+
+    shear/unknown_ignore
+
+      ⚠ unknown ignore `fake-crate`
+        ╭─[Cargo.toml:68:36]
+     67 │ [package.metadata.cargo-shear]
+     68 │ ignored = ["regex-syntax", "slab", "fake-crate"]
+        ·                                    ──────┬─────
+        ·                                          ╰── not a dependency
+        ╰────
+      help: remove from ignored list
+
+    shear/redundant_ignore
+
+      ⚠ redundant ignore `slab`
+        ╭─[Cargo.toml:68:28]
+     67 │ [package.metadata.cargo-shear]
+     68 │ ignored = ["regex-syntax", "slab", "fake-crate"]
+        ·                            ───┬──
+        ·                               ╰── dependency is used
+        ╰────
+      help: remove from ignored list
+
+    shear/summary
+
+      ✗ 8 errors
+      ⚠ 8 warnings
+
+    Advice:
+      ☞ run with `--fix` to fix 8 issues
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -197,9 +453,9 @@ fn ignored() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
     insta::assert_snapshot!(output, @r"
-    Analyzing .
+    shear/summary
 
-    No issues detected!
+      ✓ no issues found
     ");
 
     Ok(())
@@ -211,13 +467,38 @@ fn ignored_invalid() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("ignored_invalid", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/unknown_ignore
 
-    warning: 'anywho' in [package.metadata.cargo-shear] for package 'ignored_invalid' is ignored but not needed; remove it unless you're suppressing a known false positive.
+      ⚠ unknown ignore `anywho`
+       ╭─[Cargo.toml:7:12]
+     6 │ [package.metadata.cargo-shear]
+     7 │ ignored = ["anywho"]
+       ·            ────┬───
+       ·                ╰── not a dependency
+       ╰────
+      help: remove from ignored list
 
-    No issues detected!
-    ");
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -228,13 +509,38 @@ fn ignored_redundant() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("ignored_redundant", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/redundant_ignore
 
-    warning: 'anyhow' in [package.metadata.cargo-shear] for package 'ignored_redundant' is ignored but not needed; remove it unless you're suppressing a known false positive.
+      ⚠ redundant ignore `anyhow`
+        ╭─[Cargo.toml:10:12]
+      9 │ [package.metadata.cargo-shear]
+     10 │ ignored = ["anyhow"]
+        ·            ────┬───
+        ·                ╰── dependency is used
+        ╰────
+      help: remove from ignored list
 
-    No issues detected!
-    ");
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -246,9 +552,9 @@ fn ignored_workspace() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
     insta::assert_snapshot!(output, @r"
-    Analyzing .
+    shear/summary
 
-    No issues detected!
+      ✓ no issues found
     ");
 
     Ok(())
@@ -260,13 +566,38 @@ fn ignored_workspace_redundant() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("ignored_workspace_redundant", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/redundant_ignore
 
-    warning: 'anyhow' in [workspace.metadata.cargo-shear] is ignored but not needed; remove it unless you're suppressing a known false positive.
+      ⚠ redundant ignore `anyhow`
+        ╭─[Cargo.toml:10:12]
+      9 │ [workspace.metadata.cargo-shear]
+     10 │ ignored = ["anyhow"]
+        ·            ────┬───
+        ·                ╰── dependency is used
+        ╰────
+      help: remove from ignored list
 
-    No issues detected!
-    ");
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -278,9 +609,9 @@ fn ignored_workspace_merged() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
     insta::assert_snapshot!(output, @r"
-    Analyzing .
+    shear/summary
 
-    No issues detected!
+      ✓ no issues found
     ");
 
     Ok(())
@@ -293,25 +624,37 @@ fn misplaced_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/misplaced_dependency
 
-    misplaced -- Cargo.toml:
-      move to dev-dependencies:
-        anyhow
+      × misplaced dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Misplaced
+     8 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── only used in dev targets
+       ╰────
+      help: move this dependency to `[dev-dependencies]`
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -336,11 +679,51 @@ fn misplaced_optional_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("misplaced_optional", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/misplaced_optional_dependency
 
-    No issues detected!
-    ");
+      ⚠ misplaced optional dependency `anyhow`
+        ╭─[Cargo.toml:11:1]
+     10 │ # Misplaced
+     11 │ anyhow = { version = "1.0", optional = true }
+        · ───┬──
+        ·    ╰── only used in dev targets
+        ╰────
+      help: remove the `optional` flag and move to `[dev-dependencies]`
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `testing`
+       ╭─[Cargo.toml:7:12]
+     6 │ [features]
+     7 │ testing = ["dep:anyhow"]
+       ·            ──────┬─────
+       ·                  ╰── enabled here
+     8 │ 
+       ╰────
+
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -365,25 +748,37 @@ fn misplaced_platform_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/misplaced_dependency
 
-    misplaced_platform -- Cargo.toml:
-      move to dev-dependencies:
-        anyhow
+      × misplaced dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Misplaced
+     8 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── only used in dev targets
+       ╰────
+      help: move this dependency to `[target.'cfg(unix)'.dev-dependencies]`
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -410,25 +805,37 @@ fn misplaced_renamed_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/misplaced_dependency
 
-    misplaced_renamed -- Cargo.toml:
-      move to dev-dependencies:
-        anyhow_v1
+      × misplaced dependency `anyhow_v1`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Misplaced
+     8 │ anyhow_v1 = { package = "anyhow", version = "1.0" }
+       · ────┬────
+       ·     ╰── only used in dev targets
+       ╰────
+      help: move this dependency to `[dev-dependencies]`
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -458,25 +865,38 @@ fn misplaced_table_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/misplaced_dependency
 
-    misplaced_table -- Cargo.toml:
-      move to dev-dependencies:
-        anyhow
+      × misplaced dependency `anyhow`
+       ╭─[Cargo.toml:7:15]
+     6 │ # Misplaced
+     7 │ [dependencies.anyhow]
+       ·               ───┬──
+       ·                  ╰── only used in dev targets
+     8 │ version = "1.0"
+       ╰────
+      help: move this dependency to `[dev-dependencies]`
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -533,25 +953,37 @@ fn unused_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused -- Cargo.toml:
-      unused dependencies:
-        anyhow
+      × unused dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -576,25 +1008,37 @@ fn unused_build_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_build -- Cargo.toml:
-      unused dependencies:
-        anyhow
+      × unused dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -619,25 +1063,37 @@ fn unused_dev_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_dev -- Cargo.toml:
-      unused dependencies:
-        anyhow
+      × unused dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -661,11 +1117,47 @@ fn unused_feature_detect() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("unused_feature", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/unused_feature_dependency
 
-    No issues detected!
-    ");
+      ⚠ dependency `anyhow` only used in features
+        ╭─[Cargo.toml:11:1]
+     10 │ # Unused
+     11 │ anyhow = "1.0"
+        · ───┬──
+        ·    ╰── not used in code
+        ╰────
+
+    Advice: 
+      ☞ used in feature `std`
+       ╭─[Cargo.toml:7:8]
+     6 │ [features]
+     7 │ std = ["anyhow/std"]
+       ·        ──────┬─────
+       ·              ╰── enabled here
+     8 │ 
+       ╰────
+
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -688,11 +1180,50 @@ fn unused_feature_weak_detect() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("unused_feature_weak", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/unused_optional_dependency
 
-    No issues detected!
-    ");
+      ⚠ unused optional dependency `anyhow`
+        ╭─[Cargo.toml:11:1]
+     10 │ # Unused
+     11 │ anyhow = { version = "1.0", optional = true }
+        · ───┬──
+        ·    ╰── not used in code
+        ╰────
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `std`
+       ╭─[Cargo.toml:7:8]
+     6 │ [features]
+     7 │ std = ["anyhow?/std"]
+       ·        ──────┬──────
+       ·              ╰── enabled here
+     8 │ 
+       ╰────
+
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -716,25 +1247,37 @@ fn unused_naming_hyphen_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_naming_hyphen -- Cargo.toml:
-      unused dependencies:
-        serde_json
+      × unused dependency `serde_json`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ serde_json = "1.0"
+       · ─────┬────
+       ·      ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -759,25 +1302,37 @@ fn unused_naming_underscore_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_naming_underscore -- Cargo.toml:
-      unused dependencies:
-        rustc-hash
+      × unused dependency `rustc-hash`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ rustc-hash = "2.0"
+       · ─────┬────
+       ·      ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -801,11 +1356,50 @@ fn unused_optional_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("unused_optional", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/unused_optional_dependency
 
-    No issues detected!
-    ");
+      ⚠ unused optional dependency `anyhow`
+        ╭─[Cargo.toml:11:1]
+     10 │ # Unused
+     11 │ anyhow = { version = "1.0", optional = true }
+        · ───┬──
+        ·    ╰── not used in code
+        ╰────
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    Advice: 
+      ☞ used in feature `anyhow`
+       ╭─[Cargo.toml:7:11]
+     6 │ [features]
+     7 │ anyhow = ["dep:anyhow"]
+       ·           ──────┬─────
+       ·                 ╰── enabled here
+     8 │ 
+       ╰────
+
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -832,11 +1426,40 @@ fn unused_optional_implicit_detection() -> Result<(), Box<dyn Error>> {
     let (exit_code, output, _) = run_cargo_shear("unused_optional_implicit", false)?;
     assert_eq!(exit_code, ExitCode::SUCCESS);
 
-    insta::assert_snapshot!(output, @r"
-    Analyzing .
+    insta::assert_snapshot!(output, @r#"
+    shear/unused_optional_dependency
 
-    No issues detected!
-    ");
+      ⚠ unused optional dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ anyhow = { version = "1.0", optional = true }
+       · ───┬──
+       ·    ╰── not used in code
+       ╰────
+
+    Advice: 
+      ☞ removing an optional dependency may be a breaking change
+
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+    "#);
 
     Ok(())
 }
@@ -860,25 +1483,37 @@ fn unused_platform_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_platform -- Cargo.toml:
-      unused dependencies:
-        anyhow
+      × unused dependency `anyhow`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -904,25 +1539,37 @@ fn unused_renamed_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_renamed -- Cargo.toml:
-      unused dependencies:
-        anyhow_v1
+      × unused dependency `anyhow_v1`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ anyhow_v1 = { package = "anyhow", version = "1.0" }
+       · ────┬────
+       ·     ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -947,25 +1594,37 @@ fn unused_libname_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_libname -- Cargo.toml:
-      unused dependencies:
-        criterion2
+      × unused dependency `criterion2`
+       ╭─[Cargo.toml:8:1]
+     7 │ # Unused
+     8 │ criterion2 = { version = "3.0", default-features = false }
+       · ─────┬────
+       ·      ╰── not used in code
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -990,25 +1649,38 @@ fn unused_table_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_dependency
 
-    unused_table -- Cargo.toml:
-      unused dependencies:
-        anyhow
+      × unused dependency `anyhow`
+       ╭─[Cargo.toml:7:15]
+     6 │ # Unused
+     7 │ [dependencies.anyhow]
+       ·               ───┬──
+       ·                  ╰── not used in code
+     8 │ version = "1.0"
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -1033,25 +1705,37 @@ fn unused_workspace_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_workspace_dependency
 
-    root -- ./Cargo.toml:
-      unused dependencies:
-        anyhow
+      × unused workspace dependency `anyhow`
+       ╭─[Cargo.toml:7:1]
+     6 │ # Unused
+     7 │ anyhow = "1.0"
+       · ───┬──
+       ·    ╰── not used by any workspace member
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -1077,25 +1761,37 @@ fn unused_workspace_renamed_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_workspace_dependency
 
-    root -- ./Cargo.toml:
-      unused dependencies:
-        anyhow_v1
+      × unused workspace dependency `anyhow_v1`
+       ╭─[Cargo.toml:7:1]
+     6 │ # Unused
+     7 │ anyhow_v1 = { package = "anyhow", version = "1.0" }
+       · ────┬────
+       ·     ╰── not used by any workspace member
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())
@@ -1121,25 +1817,37 @@ fn unused_workspace_libname_detection() -> Result<(), Box<dyn Error>> {
     assert_eq!(exit_code, ExitCode::FAILURE);
 
     insta::assert_snapshot!(output, @r#"
-    Analyzing .
+    shear/unused_workspace_dependency
 
-    root -- ./Cargo.toml:
-      unused dependencies:
-        criterion2
+      × unused workspace dependency `criterion2`
+       ╭─[Cargo.toml:7:1]
+     6 │ # Unused
+     7 │ criterion2 = { version = "3.0", default-features = false }
+       · ─────┬────
+       ·      ╰── not used by any workspace member
+       ╰────
+      help: remove this dependency
 
+    shear/summary
 
-    cargo-shear may have detected unused dependencies incorrectly due to its limitations.
-    They can be ignored by adding the crate name to the package's Cargo.toml:
+      ✗ 1 error
 
-    [package.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    or in the workspace Cargo.toml:
-
-    [workspace.metadata.cargo-shear]
-    ignored = ["crate-name"]
-
-    To automatically fix issues, run with --fix
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+      ☞ to suppress an issue within a package
+       ╭─[Cargo.toml:2:12]
+     1 │ [package.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
+      ☞ to suppress an issue across a workspace
+       ╭─[Cargo.toml:2:12]
+     1 │ [workspace.metadata.cargo-shear]
+     2 │ ignored = ["crate-name"]
+       ·            ──────┬─────
+       ·                  ╰── add the crate name here
+       ╰────
     "#);
 
     Ok(())


### PR DESCRIPTION
- Switched to `miette` for output.
- Added "--format" and "--color" flags to CLI.
- Added new warnings: 
  - unused_optional_dependency - optional dep not used in code
  - unused_feature_dependency - dep only referenced in `[features]`, not in code
  - misplaced_optional_dependency - optional dep in `[dependencies]` but only used in dev targets
  - unknown_ignore - ignored entry for an unknown dep
  - redundant_ignore - ignored entry for a dep that's actually used

Tried to ensure this isn't too tightly coupled to `miette`, so it should be simple to add JSON, SARIF, outputs later.

Perf looks to be about the same as the last release:

```bash
> hyperfine -i -n "v1.7.0" -n "new" --warmup 5 'cargo-shear-old' 'cargo-shear'
Benchmark 1: v1.7.0
  Time (mean ± σ):     226.7 ms ±  10.5 ms    [User: 968.0 ms, System: 46.0 ms]
  Range (min … max):   215.9 ms … 249.8 ms    12 runs

Benchmark 2: new
  Time (mean ± σ):     221.1 ms ±   4.0 ms    [User: 948.4 ms, System: 50.9 ms]
  Range (min … max):   214.8 ms … 227.4 ms    13 runs

Summary
  new ran
    1.03 ± 0.05 times faster than v1.7.0
```
