### PR TITLE
Fix feature ref diagnostic to include plain dep enablements

### DIFF
--- a/src/dependency_analyzer.rs
+++ b/src/dependency_analyzer.rs
@@ -45,6 +45,11 @@ pub enum FeatureRef {
     /// [features]
     /// feature = ["dep:foo"]
     /// ```
+    ///
+    /// ```toml
+    /// [features]
+    /// feature = ["foo"]
+    /// ```
     Explicit { feature: Spanned<String>, value: Spanned<String> },
 
     /// Dependency feature enablement.
@@ -65,14 +70,11 @@ pub enum FeatureRef {
 }
 
 impl FeatureRef {
-    fn parse(feature: &Spanned<String>, value: &Spanned<String>) -> Option<(String, Self)> {
+    fn parse(feature: &Spanned<String>, value: &Spanned<String>) -> (String, Self) {
         // Handle `dep:foo` syntax
         if let Some(dep) = value.as_ref().strip_prefix("dep:") {
             let import = dep.replace('-', "_");
-            return Some((
-                import,
-                Self::Explicit { feature: feature.clone(), value: value.clone() },
-            ));
+            return (import, Self::Explicit { feature: feature.clone(), value: value.clone() });
         }
 
         // Handle `foo/bar` and `foo?/bar` syntax
@@ -88,11 +90,13 @@ impl FeatureRef {
                 Self::DepFeature { feature: feature.clone(), value: value.clone() }
             };
 
-            return Some((import, feature));
+            return (import, feature);
         }
 
-        // Assume this is enabling another feature
-        None
+        // Assume this is enabling another feature.
+        // May be a dependency, so worth tracking.
+        let import = value.as_ref().replace('-', "_");
+        (import, Self::Explicit { feature: feature.clone(), value: value.clone() })
     }
 }
 
@@ -297,9 +301,8 @@ impl DependencyAnalyzer {
     fn analyze_features(categorized: &mut CategorizedImports, manifest: &Manifest) {
         for (feature, values) in &manifest.features {
             for value in values {
-                if let Some((import, feature)) = FeatureRef::parse(feature, value) {
-                    categorized.features.entry(import).or_default().push(feature);
-                }
+                let (import, feature) = FeatureRef::parse(feature, value);
+                categorized.features.entry(import).or_default().push(feature);
             }
         }
 


### PR DESCRIPTION
Resolves #354

The "used in feature" diagnostic now includes plain dep enablements, like "foo" instead of "dep:foo".

```
shear/unused_optional_dependency

  ⚠ unused optional dependency `smol`
    ╭─[sqlx-macros-core/Cargo.toml:64:1]
 63 │ async-std = { workspace = true, optional = true }
 64 │ smol = { workspace = true, optional = true }
    · ──┬─
    ·   ╰── not used in code
 65 │ tokio = { workspace = true, optional = true }
    ╰────

Advice:
  ☞ removing an optional dependency may be a breaking change

Advice:
  ☞ used in feature `_rt-smol`
    ╭─[sqlx-macros-core/Cargo.toml:17:13]
 16 │ _rt-async-std = ["async-std", "sqlx-core/_rt-async-std"]
 17 │ _rt-smol = ["smol", "sqlx-core/_rt-smol"]
    ·             ───┬──
    ·                ╰── enabled here
 18 │ _rt-tokio = ["tokio", "sqlx-core/_rt-tokio"]
    ╰────
```