### PR TITLE
Show cargo metadata output to users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,7 @@ impl<W: Write> CargoShear<W> {
             .features(CargoOpt::AllFeatures)
             .current_dir(&self.options.path)
             .other_options(extra_opts)
+            .verbose(true)
             .exec()
             .map_err(|e| anyhow::anyhow!("Metadata error: {e}"))?;
 


### PR DESCRIPTION
closes #348

## Summary

Previously, `cargo metadata` ran silently, leaving users wondering why the tool appeared to hang on fresh clones or when the registry index needed updating. This PR adds `.verbose(true)` to the `MetadataCommand` so users see helpful progress messages.

## Example Output

When running on the codex-rs project:

```
codex/codex-rs  main ❯ ~/github/cargo-shear/target/release/cargo-shear
    Updating git submodule `https://github.com/madler/zlib.git`
    Updating git submodule `https://github.com/glennrp/libpng.git`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)