### PR TITLE
chore: release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0](https://github.com/Boshen/cargo-shear/compare/v1.8.0...v1.9.0) - 2025-12-13
+
+### <!-- 0 -->🚀 Features
+- warn empty files ([#368](https://github.com/Boshen/cargo-shear/pull/368)) (by @Copilot)
+
+### <!-- 9 -->💼 Other
+- Don't flag ignore as redundant if it suppresses another warning ([#367](https://github.com/Boshen/cargo-shear/pull/367)) (by @CathalMullan)
+
+### Contributors
+
+* @Copilot
+* @CathalMullan
+
 ## [1.8.0](https://github.com/Boshen/cargo-shear/compare/v1.7.2...v1.8.0) - 2025-12-13
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.8.0 -> 1.9.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.9.0](https://github.com/Boshen/cargo-shear/compare/v1.8.0...v1.9.0) - 2025-12-13

### <!-- 0 -->🚀 Features
- warn empty files ([#368](https://github.com/Boshen/cargo-shear/pull/368)) (by @Copilot)

### <!-- 9 -->💼 Other
- Don't flag ignore as redundant if it suppresses another warning ([#367](https://github.com/Boshen/cargo-shear/pull/367)) (by @CathalMullan)

### Contributors

* @Copilot
* @CathalMullan
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).