### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1](https://github.com/Boshen/cargo-shear/compare/v1.9.0...v1.9.1) - 2025-12-15
+
+### <!-- 9 -->💼 Other
+- Fix redundant_ignore_path warning for empty files ([#382](https://github.com/Boshen/cargo-shear/pull/382)) (by @Copilot)
+- Add JSON output format for CI integration ([#371](https://github.com/Boshen/cargo-shear/pull/371)) (by @Copilot)
+- Prevent duplicate path warnings in root workspace packages ([#383](https://github.com/Boshen/cargo-shear/pull/383)) (by @CathalMullan)
+- Print files as list, rather than tree ([#377](https://github.com/Boshen/cargo-shear/pull/377)) (by @CathalMullan)
+
+### Contributors
+
+* @Copilot
+* @CathalMullan
+* @renovate[bot]
+
 ## [1.9.0](https://github.com/Boshen/cargo-shear/compare/v1.8.0...v1.9.0) - 2025-12-13
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.9.0 -> 1.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.9.1](https://github.com/Boshen/cargo-shear/compare/v1.9.0...v1.9.1) - 2025-12-15

### <!-- 9 -->💼 Other
- Fix redundant_ignore_path warning for empty files ([#382](https://github.com/Boshen/cargo-shear/pull/382)) (by @Copilot)
- Add JSON output format for CI integration ([#371](https://github.com/Boshen/cargo-shear/pull/371)) (by @Copilot)
- Prevent duplicate path warnings in root workspace packages ([#383](https://github.com/Boshen/cargo-shear/pull/383)) (by @CathalMullan)
- Print files as list, rather than tree ([#377](https://github.com/Boshen/cargo-shear/pull/377)) (by @CathalMullan)

### Contributors

* @Copilot
* @CathalMullan
* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).