### PR TITLE
Prevent duplicate path warnings in root workspace packages

### DIFF
--- a/src/package_analyzer.rs
+++ b/src/package_analyzer.rs
@@ -217,6 +217,17 @@ impl<'a> PackageAnalyzer<'a> {
             .files
             .keys()
             .filter(|path| {
+                // Skip files belonging to other packages when analyzing workspace root
+                if self.ctx.directory == self.ctx.workspace.root
+                    && self.ctx.workspace.packages.len() > 1
+                {
+                    for pkg in &self.ctx.workspace.packages {
+                        if pkg != &self.ctx.directory && path.starts_with(pkg) {
+                            return false;
+                        }
+                    }
+                }
+
                 let path_bytes = path.as_os_str().as_encoded_bytes();
                 path_bytes.starts_with(dir_bytes)
                     && path_bytes.get(dir_bytes.len()) == Some(&b'/')

--- a/src/package_processor.rs
+++ b/src/package_processor.rs
@@ -352,7 +352,7 @@ impl PackageProcessor {
     ) -> WorkspaceAnalysis {
         let mut result = WorkspaceAnalysis::default();
 
-        if ctx.packages <= 1 {
+        if ctx.packages.len() <= 1 {
             return result;
         }
 


### PR DESCRIPTION
Fixes #374

Prevents duplicate path warnings when processing monorepos with a package at ".".

Tested against:

```diff
=== Testing clap ===
--- cargo-shear-old.out	2025-12-15 12:38:22.978551412 +0000
+++ cargo-shear.out	2025-12-15 12:38:22.838550914 +0000
@@ -1,19 +1,6 @@
 shear/unlinked_files

-  ⚠ 121 unlinked files in `clap`
-  │ clap_complete/tests/testsuite/bash.rs
-  │ clap_complete/tests/testsuite/common.rs
-  │ clap_complete/tests/testsuite/elvish.rs
-  │ clap_complete/tests/testsuite/engine.rs
-  │ clap_complete/tests/testsuite/fish.rs
-  │ clap_complete/tests/testsuite/general.rs
-  │ clap_complete/tests/testsuite/powershell.rs
-  │ clap_complete/tests/testsuite/zsh.rs
-  │ clap_lex/tests/testsuite/lexer.rs
-  │ clap_lex/tests/testsuite/parsed.rs
-  │ clap_lex/tests/testsuite/shorts.rs
-  │ clap_mangen/tests/testsuite/common.rs
-  │ clap_mangen/tests/testsuite/roff.rs
+  ⚠ 108 unlinked files in `clap`
   │ tests/builder/action.rs
   │ tests/builder/app_settings.rs
   │ tests/builder/arg_aliases.rs

=== Testing sqlx ===
--- cargo-shear-old.out	2025-12-15 12:38:24.526556918 +0000
+++ cargo-shear.out	2025-12-15 12:38:24.350556292 +0000
@@ -24,9 +24,7 @@

 shear/unlinked_files

-  ⚠ 15 unlinked files in `sqlx`
-  │ sqlx-core/src/io/buf_stream.rs
-  │ sqlx-core/src/io/write_and_flush.rs
+  ⚠ 13 unlinked files in `sqlx`
   │ tests/mssql/describe.rs
   │ tests/mssql/macros.rs
   │ tests/mssql/mssql.rs

=== Testing proc-macro2 ===
--- cargo-shear-old.out	2025-12-15 12:38:25.010558640 +0000
+++ cargo-shear.out	2025-12-15 12:38:24.970558497 +0000
@@ -1,18 +1,12 @@
 shear/unlinked_files

-  ⚠ 1 unlinked file in `proc-macro2`
-  │ tests/ui/test-not-send.rs
-  help: delete this file
-
-shear/unlinked_files
-
   ⚠ 1 unlinked file in `proc-macro2-ui-test`
   │ test-not-send.rs
   help: delete this file

 shear/summary

-  ⚠ 2 warnings
+  ⚠ 1 warning

 Advice:
   ☞ to suppress a file issue

=== Testing tikv ===
--- cargo-shear-old.out	2025-12-15 12:38:26.122562595 +0000
+++ cargo-shear.out	2025-12-15 12:38:25.630560845 +0000
@@ -1842,15 +1842,6 @@
  49 │   # NB: the "openssl" feature does not make grpcio-sys v0.10 depends on
     ╰────

-shear/unlinked_files
-
-  ⚠ 4 unlinked files in `tikv`
-  │ components/engine_panic/src/io_limiter.rs
-  │ fuzz/fuzzer-afl/template.rs
-  │ fuzz/fuzzer-honggfuzz/template.rs
-  │ fuzz/fuzzer-libfuzzer/template.rs
-  help: delete these files
-
 shear/empty_files

   ⚠ 4 empty files in `tikv`
@@ -2005,7 +1996,7 @@
 shear/summary

   ✗ 157 errors
-  ⚠ 12 warnings
+  ⚠ 11 warnings

 Advice:
   ☞ run with `--fix` to fix 157 issues

=== Testing nushell ===
--- cargo-shear-old.out	2025-12-15 12:38:32.954586915 +0000
+++ cargo-shear.out	2025-12-15 12:38:32.610585689 +0000
@@ -58,14 +58,6 @@
  331 │
      ╰────

-shear/unlinked_files
-
-  ⚠ 3 unlinked files in `nu`
-  │ crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
-  │ crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
-  │ crates/nu-command/tests/commands/start.rs
-  help: delete these files
-
 shear/unused_dependency

   × unused dependency `nu-path`
@@ -473,7 +465,7 @@
 shear/summary

   ✗ 27 errors
-  ⚠ 8 warnings
+  ⚠ 7 warnings

 Advice:
   ☞ run with `--fix` to fix 27 issues
```