### PR TITLE
chore: release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/Boshen/cargo-shear/compare/v1.9.1...v1.10.0) - 2026-03-10
+
+### <!-- 0 -->🚀 Features
+- detect test/doctest flag mismatches ([#444](https://github.com/Boshen/cargo-shear/pull/444)) (by @Boshen)
+
+### <!-- 1 -->🐛 Bug Fixes
+- add dedicated environment for release secret ([#445](https://github.com/Boshen/cargo-shear/pull/445)) (by @Boshen)
+
+### <!-- 3 -->📚 Documentation
+- clarify single-platform execution for CI ([#405](https://github.com/Boshen/cargo-shear/pull/405)) (by @Copilot)
+- declare maintenance mode ([#393](https://github.com/Boshen/cargo-shear/pull/393)) (by @Boshen)
+
+### <!-- 9 -->💼 Other
+- Add uutils/coreutils to the list of Trophy ([#413](https://github.com/Boshen/cargo-shear/pull/413)) (by @sylvestre)
+- Fix detection of root-scoped paths in serde attributes ([#409](https://github.com/Boshen/cargo-shear/pull/409)) (by @Copilot)
+- Revise maintenance mode note in README ([#394](https://github.com/Boshen/cargo-shear/pull/394)) (by @Boshen)
+- Add --deny-warnings flag to treat warnings as errors ([#391](https://github.com/Boshen/cargo-shear/pull/391)) (by @Copilot)
+- Suggest `--expand` when known codegen crates are in use ([#387](https://github.com/Boshen/cargo-shear/pull/387)) (by @CathalMullan)
+- Add Windows CI, fix path separator handling ([#389](https://github.com/Boshen/cargo-shear/pull/389)) (by @CathalMullan)
+- Add redundant workspace ignored-paths detection ([#385](https://github.com/Boshen/cargo-shear/pull/385)) (by @CathalMullan)
+
+### Contributors
+
+* @Boshen
+* @renovate[bot]
+* @sylvestre
+* @Copilot
+* @CathalMullan
+
 ## [1.9.1](https://github.com/Boshen/cargo-shear/compare/v1.9.0...v1.9.1) - 2025-12-15
 
 ### <!-- 9 -->💼 Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.9.1"
+version = "1.10.0"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.9.1 -> 1.10.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.10.0](https://github.com/Boshen/cargo-shear/compare/v1.9.1...v1.10.0) - 2026-03-10

### <!-- 0 -->🚀 Features
- detect test/doctest flag mismatches ([#444](https://github.com/Boshen/cargo-shear/pull/444)) (by @Boshen)

### <!-- 1 -->🐛 Bug Fixes
- add dedicated environment for release secret ([#445](https://github.com/Boshen/cargo-shear/pull/445)) (by @Boshen)

### <!-- 3 -->📚 Documentation
- clarify single-platform execution for CI ([#405](https://github.com/Boshen/cargo-shear/pull/405)) (by @Copilot)
- declare maintenance mode ([#393](https://github.com/Boshen/cargo-shear/pull/393)) (by @Boshen)

### <!-- 9 -->💼 Other
- Add uutils/coreutils to the list of Trophy ([#413](https://github.com/Boshen/cargo-shear/pull/413)) (by @sylvestre)
- Fix detection of root-scoped paths in serde attributes ([#409](https://github.com/Boshen/cargo-shear/pull/409)) (by @Copilot)
- Revise maintenance mode note in README ([#394](https://github.com/Boshen/cargo-shear/pull/394)) (by @Boshen)
- Add --deny-warnings flag to treat warnings as errors ([#391](https://github.com/Boshen/cargo-shear/pull/391)) (by @Copilot)
- Suggest `--expand` when known codegen crates are in use ([#387](https://github.com/Boshen/cargo-shear/pull/387)) (by @CathalMullan)
- Add Windows CI, fix path separator handling ([#389](https://github.com/Boshen/cargo-shear/pull/389)) (by @CathalMullan)
- Add redundant workspace ignored-paths detection ([#385](https://github.com/Boshen/cargo-shear/pull/385)) (by @CathalMullan)

### Contributors

* @Boshen
* @renovate[bot]
* @sylvestre
* @Copilot
* @CathalMullan
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).