### PR TITLE
fix: add dedicated environment for release secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
## Summary
- Add `environment: release` to the release-plz job so the `RELEASE_PLZ_TOKEN` secret is accessed within a dedicated GitHub environment, fixing a zizmor `secrets-outside-env` warning.

> **Note:** A "release" environment needs to be created in the repo settings with the `RELEASE_PLZ_TOKEN` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)