### PR TITLE
fix: remove empty TOML tables after fixing

### DIFF
--- a/src/cargo_toml_editor.rs
+++ b/src/cargo_toml_editor.rs
@@ -17,6 +17,8 @@ use crate::{
     package_processor::{MisplacedDependency, UnusedDependency, UnusedWorkspaceDependency},
 };
 
+const DEP_TABLE_KEYS: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
+
 /// Provides methods to edit Cargo.toml files and remove unused dependencies.
 pub struct CargoTomlEditor;
 
@@ -58,6 +60,7 @@ impl CargoTomlEditor {
 
         let count = removed.len();
         Self::fix_features(manifest, &removed);
+        Self::cleanup_empty_tables(manifest);
         count
     }
 
@@ -88,6 +91,7 @@ impl CargoTomlEditor {
 
         let count = removed.len();
         Self::fix_features(manifest, &removed);
+        Self::cleanup_empty_tables(manifest);
         count
     }
 
@@ -113,6 +117,7 @@ impl CargoTomlEditor {
             }
         }
 
+        Self::cleanup_empty_tables(manifest);
         count
     }
 
@@ -183,11 +188,15 @@ impl CargoTomlEditor {
 
     /// Remove a flag (e.g. `test` or `doctest`) from the `[lib]` section.
     pub fn remove_lib_flag(manifest: &mut DocumentMut, flag: &str) -> bool {
-        manifest
+        let removed = manifest
             .get_mut("lib")
             .and_then(|item| item.as_table_mut())
             .and_then(|table| table.remove(flag))
-            .is_some()
+            .is_some();
+        if removed {
+            Self::cleanup_empty_tables(manifest);
+        }
+        removed
     }
 
     /// Set a flag to `false` in the `[lib]` section, creating the section if needed.
@@ -197,6 +206,68 @@ impl CargoTomlEditor {
         }
         if let Some(table) = manifest.get_mut("lib").and_then(|item| item.as_table_mut()) {
             table[flag] = value(false);
+        }
+    }
+
+    fn cleanup_empty_tables(manifest: &mut DocumentMut) {
+        // Clean root-level dep tables
+        for key in DEP_TABLE_KEYS {
+            if manifest.get(key).and_then(|i| i.as_table()).is_some_and(Table::is_empty) {
+                manifest.remove(key);
+            }
+        }
+
+        // Clean target-specific tables (bottom-up)
+        if let Some(targets) = manifest.get_mut("target").and_then(|i| i.as_table_mut()) {
+            let target_keys: Vec<String> = targets.iter().map(|(k, _)| k.to_owned()).collect();
+            for cfg_key in &target_keys {
+                if let Some(target) = targets.get_mut(cfg_key).and_then(|i| i.as_table_mut()) {
+                    for dep_key in DEP_TABLE_KEYS {
+                        if target
+                            .get(dep_key)
+                            .and_then(|i| i.as_table())
+                            .is_some_and(Table::is_empty)
+                        {
+                            target.remove(dep_key);
+                        }
+                    }
+                }
+                if targets.get(cfg_key).and_then(|i| i.as_table()).is_some_and(Table::is_empty) {
+                    targets.remove(cfg_key);
+                }
+            }
+        }
+        if manifest.get("target").and_then(|i| i.as_table()).is_some_and(Table::is_empty) {
+            manifest.remove("target");
+        }
+
+        // Clean workspace.dependencies
+        if let Some(workspace) = manifest.get_mut("workspace").and_then(|i| i.as_table_mut())
+            && workspace.get("dependencies").and_then(|i| i.as_table()).is_some_and(Table::is_empty)
+        {
+            workspace.remove("dependencies");
+        }
+
+        // Clean empty feature entries, then [features]
+        if let Some(features) = manifest.get_mut("features").and_then(|i| i.as_table_mut()) {
+            let keys: Vec<String> = features.iter().map(|(k, _)| k.to_owned()).collect();
+            for key in &keys {
+                if features
+                    .get(key)
+                    .and_then(|i| i.as_array())
+                    .is_some_and(toml_edit::Array::is_empty)
+                {
+                    features.remove(key);
+                }
+            }
+        }
+        if manifest.get("features").and_then(|i| i.as_table()).is_some_and(Table::is_empty) {
+            manifest.remove("features");
+        }
+
+        // Clean [lib]
+        if manifest.get("lib").and_then(|i| i.as_table()).is_some_and(Table::is_empty) {
+            manifest.remove("lib");
         }
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1303,6 +1303,10 @@ fn unused_fix() -> Result<(), Box<dyn Error>> {
     let manifest = Manifest::from_path(temp_dir.path().join("Cargo.toml"))?;
     assert!(!manifest.dependencies.contains_key("anyhow"));
 
+    // Empty `[dependencies]` table should be removed after fix
+    let content = fs::read_to_string(temp_dir.path().join("Cargo.toml"))?;
+    assert!(!content.contains("[dependencies]"));
+
     Ok(())
 }
 
@@ -1781,6 +1785,10 @@ fn unused_platform_fix() -> Result<(), Box<dyn Error>> {
     let manifest = Manifest::from_path(temp_dir.path().join("Cargo.toml"))?;
     let windows = manifest.target.get("cfg(windows)");
     assert!(!windows.is_some_and(|table| table.dependencies.contains_key("anyhow")));
+
+    // Empty `[target]` table chain should be removed after fix
+    let content = fs::read_to_string(temp_dir.path().join("Cargo.toml"))?;
+    assert!(!content.contains("[target"));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- When `--fix` removes the last dependency from a table, the empty table header (e.g. `[dependencies]`, `[target.'cfg(...)'.dependencies]`) was left behind
- Add `cleanup_empty_tables()` to `CargoTomlEditor` that removes empty tables after modifications
- Handles: root dep tables, target dep tables (bottom-up), `[workspace.dependencies]`, empty feature entries, and `[lib]`
- Called from `remove_dependencies()`, `remove_workspace_deps()`, `move_to_dev_dependencies()`, and `remove_lib_flag()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)