### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/Boshen/cargo-shear/compare/v1.10.0...v2.0.0) - 2026-03-14
+
+### <!-- 0 -->🚀 Features
+- add `--format github` for GitHub Actions workflow commands ([#452](https://github.com/Boshen/cargo-shear/pull/452)) (by @Boshen)
+
+### <!-- 1 -->🐛 Bug Fixes
+- package-level ignored deps removed from workspace dependencies ([#450](https://github.com/Boshen/cargo-shear/pull/450)) (by @NeelChotai)
+- handle artifact/bindep dependencies with empty import names ([#448](https://github.com/Boshen/cargo-shear/pull/448)) (by @Boshen)
+- remove empty TOML tables after fixing ([#446](https://github.com/Boshen/cargo-shear/pull/446)) (by @Boshen)
+
+### Contributors
+
+* @Boshen
+* @NeelChotai
+
 ## [1.10.0](https://github.com/Boshen/cargo-shear/compare/v1.9.1...v1.10.0) - 2026-03-10
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.10.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.10.0"
+version = "2.0.0"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.10.0 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `cargo-shear` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant OutputFormat:GitHub in /tmp/.tmp6TxL9l/cargo-shear/src/output.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/Boshen/cargo-shear/compare/v1.10.0...v2.0.0) - 2026-03-14

### <!-- 0 -->🚀 Features
- add `--format github` for GitHub Actions workflow commands ([#452](https://github.com/Boshen/cargo-shear/pull/452)) (by @Boshen)

### <!-- 1 -->🐛 Bug Fixes
- package-level ignored deps removed from workspace dependencies ([#450](https://github.com/Boshen/cargo-shear/pull/450)) (by @NeelChotai)
- handle artifact/bindep dependencies with empty import names ([#448](https://github.com/Boshen/cargo-shear/pull/448)) (by @Boshen)
- remove empty TOML tables after fixing ([#446](https://github.com/Boshen/cargo-shear/pull/446)) (by @Boshen)

### Contributors

* @Boshen
* @NeelChotai
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).