### PR TITLE
chore: release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0](https://github.com/Boshen/cargo-shear/compare/v1.11.2...v1.12.0) - 2026-05-14
+
+### <!-- 0 -->🚀 Features
+- gate test/doctest flag mismatch detection behind --check-test-targets ([#494](https://github.com/Boshen/cargo-shear/pull/494)) (by @Boshen)
+
+### <!-- 3 -->📚 Documentation
+- consolidate agent docs and rewrite source comments ([#495](https://github.com/Boshen/cargo-shear/pull/495)) (by @Boshen)
+
+### Contributors
+
+* @Boshen
+* @renovate[bot]
+
 ## [1.11.2](https://github.com/Boshen/cargo-shear/compare/v1.11.1...v1.11.2) - 2026-03-15
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.11.2"
+version = "1.12.0"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.11.2 -> 1.12.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.12.0](https://github.com/Boshen/cargo-shear/compare/v1.11.2...v1.12.0) - 2026-05-14

### <!-- 0 -->🚀 Features
- gate test/doctest flag mismatch detection behind --check-test-targets ([#494](https://github.com/Boshen/cargo-shear/pull/494)) (by @Boshen)

### <!-- 3 -->📚 Documentation
- consolidate agent docs and rewrite source comments ([#495](https://github.com/Boshen/cargo-shear/pull/495)) (by @Boshen)

### Contributors

* @Boshen
* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).