### PR TITLE
feat: add `ignore-test-warnings` config option to suppress test/doctest warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ ignored = ["crate-name"]
 ignored-paths = ["*/proto/*.rs"]
 ```
 
+### Ignore test/doctest warnings
+
+In multi-package workspaces, `cargo shear` warns when a target has `test = true` or `doctest = true` (the defaults) but contains no tests or doc tests. To suppress these warnings without setting `test = false` in `Cargo.toml`, use `ignore-test-warnings`:
+
+```toml
+[package.metadata.cargo-shear]
+ignore-test-warnings = true
+```
+
+This can also be set at the workspace level to suppress the warnings for all packages:
+
+```toml
+[workspace.metadata.cargo-shear]
+ignore-test-warnings = true
+```
+
 Otherwise please report the issue as a bug.
 
 ## CI

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -169,6 +169,8 @@ pub struct ShearConfig {
     pub ignored: FxHashSet<Spanned<String>>,
     #[serde(default, rename = "ignored-paths")]
     pub ignored_paths: Vec<SpannedGlob>,
+    #[serde(default, rename = "ignore-test-warnings")]
+    pub ignore_test_warnings: bool,
 }
 
 #[derive(Deserialize, Default)]

--- a/src/package_processor.rs
+++ b/src/package_processor.rs
@@ -442,6 +442,8 @@ impl PackageProcessor {
 
         // Analyze test/doctest mismatches
         let is_workspace = ctx.workspace.packages.len() > 1;
+        let ignore_test_warnings = ctx.manifest.package.metadata.cargo_shear.ignore_test_warnings
+            || ctx.workspace.manifest.workspace.metadata.cargo_shear.ignore_test_warnings;
         for info in &used_imports.target_test_info {
             #[expect(clippy::wildcard_enum_match_arm, reason = "Only lib-like targets reach here")]
             let kind_str = match &info.target_kind {
@@ -460,7 +462,7 @@ impl PackageProcessor {
                 });
             }
 
-            if is_workspace && info.test_enabled && !info.has_tests {
+            if is_workspace && info.test_enabled && !info.has_tests && !ignore_test_warnings {
                 result.test_enabled_without_tests.push(TestEnabledWithoutTests {
                     target_name: info.target_name.clone(),
                     target_kind: kind_str.to_owned(),
@@ -473,7 +475,7 @@ impl PackageProcessor {
                     .push(DoctestDisabledWithDoctests { target_name: info.target_name.clone() });
             }
 
-            if is_workspace && info.doctest_enabled && !info.has_doctests {
+            if is_workspace && info.doctest_enabled && !info.has_doctests && !ignore_test_warnings {
                 result
                     .doctest_enabled_without_doctests
                     .push(DoctestEnabledWithoutDoctests { target_name: info.target_name.clone() });

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored/Cargo.toml
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/*"]
+resolver = "3"

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/with_tests/Cargo.toml
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/with_tests/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "with_tests"
+version = "0.1.0"
+edition = "2024"

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/with_tests/src/lib.rs
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/with_tests/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(add(2, 2), 4);
+    }
+}

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/without_tests/Cargo.toml
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/without_tests/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "without_tests"
+version = "0.1.0"
+edition = "2024"
+
+[package.metadata.cargo-shear]
+ignore-test-warnings = true

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/without_tests/src/lib.rs
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored/crates/without_tests/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/Cargo.toml
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["crates/*"]
+resolver = "3"
+
+[workspace.metadata.cargo-shear]
+ignore-test-warnings = true

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/with_tests/Cargo.toml
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/with_tests/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "with_tests"
+version = "0.1.0"
+edition = "2024"

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/with_tests/src/lib.rs
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/with_tests/src/lib.rs
@@ -1,0 +1,13 @@
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(add(2, 2), 4);
+    }
+}

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/without_tests/Cargo.toml
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/without_tests/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "without_tests"
+version = "0.1.0"
+edition = "2024"

--- a/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/without_tests/src/lib.rs
+++ b/tests/fixtures/test_enabled_without_tests_workspace_ignored_workspace/crates/without_tests/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2303,6 +2303,43 @@ fn test_enabled_without_tests_workspace_fix() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+// In a workspace, `ignore-test-warnings = true` in package config suppresses test/doctest warnings for that package only.
+#[test]
+fn test_enabled_without_tests_workspace_ignored() -> Result<(), Box<dyn Error>> {
+    let (exit_code, output, _temp_dir) =
+        CargoShearRunner::new("test_enabled_without_tests_workspace_ignored").run()?;
+    assert_eq!(exit_code, ExitCode::SUCCESS);
+    // `without_tests` warnings suppressed; `with_tests` still warns about missing doc tests
+    insta::assert_snapshot!(output, @r#"
+    shear/doctest_enabled_without_doctests
+
+      ⚠ `doctest = true` on lib target `with_tests` but source contains no doc tests
+      help: set `doctest = false` to avoid running doc tests for this target
+
+    shear/summary
+
+      ⚠ 1 warning
+
+    Advice:
+      ☞ run with `--fix` to fix 1 issue
+    "#);
+    Ok(())
+}
+
+// In a workspace, `ignore-test-warnings = true` in workspace config suppresses test/doctest warnings for all packages.
+#[test]
+fn test_enabled_without_tests_workspace_ignored_workspace() -> Result<(), Box<dyn Error>> {
+    let (exit_code, output, _temp_dir) =
+        CargoShearRunner::new("test_enabled_without_tests_workspace_ignored_workspace").run()?;
+    assert_eq!(exit_code, ExitCode::SUCCESS);
+    insta::assert_snapshot!(output, @r#"
+    shear/summary
+
+      ✓ no issues found
+    "#);
+    Ok(())
+}
+
 // JSON output format should produce valid JSON with structured diagnostic data.
 #[test]
 fn json_output_format() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Adds `ignore-test-warnings = true` to `[package.metadata.cargo-shear]`
or `[workspace.metadata.cargo-shear]` to opt out of
`shear/test_enabled_without_tests` and
`shear/doctest_enabled_without_doctests` warnings without having to set
`test = false` / `doctest = false` in Cargo.toml.

Documents the new option in the README under the Configuration section.

Closes #468

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
