### PR TITLE
Add line count diff thanks to cargo sheer from vinhnx/vtcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ By default, warnings (such as empty files, unlinked files, and unused optional d
 * -184 lines from [turbopack](https://github.com/vercel/next.js/pull/80121)
 * -625 lines from [openai/codex](https://github.com/openai/codex/pull/3338)
 * -69 lines from [uutils/coreutils](https://github.com/uutils/coreutils/pull/10404)
+* -1,588 lines from [vinhnx/vtcode](https://github.com/vinhnx/VTCode/pull/646)
 
 ## [Sponsored By](https://github.com/sponsors/Boshen)
 


### PR DESCRIPTION
Hi,

This PR adds a line count report for my coding agent, VT Code. Thanks to `cargo sheer` I was able to clean up quite a lot of unused deps and code. 

Thank you for building `cargo sheer`!