### PR TITLE
chore: release v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.1](https://github.com/Boshen/cargo-shear/compare/v1.12.0...v1.12.1) - 2026-05-16
+
+### <!-- 1 -->🐛 Bug Fixes
+- *(expand)* include dev-deps so cfg(test) macros expand correctly ([#502](https://github.com/Boshen/cargo-shear/pull/502)) (by @Boshen)
+- collect imports inside cfg_attr meta wrappers ([#501](https://github.com/Boshen/cargo-shear/pull/501)) (by @Boshen)
+
+### <!-- 9 -->💼 Other
+- Add line count diff thanks to cargo sheer from vinhnx/vtcode ([#496](https://github.com/Boshen/cargo-shear/pull/496)) (by @vinhnx)
+
+### Contributors
+
+* @Boshen
+* @vinhnx
+
 ## [1.12.0](https://github.com/Boshen/cargo-shear/compare/v1.11.2...v1.12.0) - 2026-05-14
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.12.0"
+version = "1.12.1"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.12.0 -> 1.12.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.12.1](https://github.com/Boshen/cargo-shear/compare/v1.12.0...v1.12.1) - 2026-05-16

### <!-- 1 -->🐛 Bug Fixes
- *(expand)* include dev-deps so cfg(test) macros expand correctly ([#502](https://github.com/Boshen/cargo-shear/pull/502)) (by @Boshen)
- collect imports inside cfg_attr meta wrappers ([#501](https://github.com/Boshen/cargo-shear/pull/501)) (by @Boshen)

### <!-- 9 -->💼 Other
- Add line count diff thanks to cargo sheer from vinhnx/vtcode ([#496](https://github.com/Boshen/cargo-shear/pull/496)) (by @vinhnx)

### Contributors

* @Boshen
* @vinhnx
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).