### PR TITLE
ci: create release as draft, undraft after binary upload

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 defaults:
   run:
@@ -77,3 +77,18 @@ jobs:
           zip: windows
           features: allocator
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    name: Publish Release
+    needs: upload-assets
+    if: github.repository_owner == 'Boshen'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Undraft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: gh release edit "$TAG" --draft=false --repo "$REPO"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,9 @@
 [workspace]
 features_always_increment_minor = true
+# Create the GitHub release as a draft so release-binaries.yml can upload
+# assets to it. A follow-up job in that workflow undrafts the release after
+# all binaries are uploaded.
+git_release_draft = true
 
 [changelog]
 body = """


### PR DESCRIPTION
## Summary

The v1.12.1 binary release [failed](https://github.com/Boshen/cargo-shear/actions/runs/25957537386/job/76306847425) with:

```
HTTP 422: Cannot upload assets to an immutable release.
```

GitHub now treats published releases as immutable, so `taiki-e/upload-rust-binary-action` can no longer attach assets after release-plz publishes the release.

## Changes

- `release-plz.toml`: set `git_release_draft = true` so release-plz creates the GH release as a draft (drafts remain mutable).
- `.github/workflows/release-binaries.yml`:
  - trigger on `release: created` instead of `published` (fires when release-plz saves the draft).
  - add a `publish-release` job that `needs: upload-assets` and runs `gh release edit <tag> --draft=false` to undraft only after every matrix target succeeds.

If any matrix target fails, the release stays as a draft and can be retried or undrafted manually.

## Notes

- The undraft step uses the default `GITHUB_TOKEN`, so the resulting `published` event does not re-trigger this workflow (Actions suppresses events from `GITHUB_TOKEN`).
- v1.12.1's release is already published-immutable; this PR only fixes future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)