### PR TITLE
ci: skip CC=clang on Windows and drop unsupported ref input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-        with:
-          ref: refs/tags/${{ fromJSON(needs.release-plz.outputs.releases)[0].tag }}
 
       - name: Set environment variables
-        run: echo "CC=clang" >> $GITHUB_ENV # for mimalloc
+        if: ${{ !contains(matrix.os, 'windows') }}
+        run: echo "CC=clang" >> $GITHUB_ENV # for mimalloc cross-compilation; on Windows let cc-rs pick MSVC (clang lacks __ldar64/__stlr64 in MSVC-compat mode on aarch64)
 
       - uses: oxc-project/setup-rust@23f38cfb0c04af97a055f76acee94d5be71c7c82 # v1.0.16
 
@@ -96,7 +95,6 @@ jobs:
           tar: all
           zip: windows
           features: allocator
-          ref: refs/tags/${{ fromJSON(needs.release-plz.outputs.releases)[0].tag }}
           dry-run: true
           dry-run-intended: true
 
@@ -116,8 +114,6 @@ jobs:
       contents: write
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-        with:
-          ref: refs/tags/${{ fromJSON(needs.release-plz.outputs.releases)[0].tag }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:


### PR DESCRIPTION
## Summary

Two issues surfaced in the v1.12.3 release run (https://github.com/Boshen/cargo-shear/actions/runs/25993853943):

- **`aarch64-pc-windows-msvc` build failed** with `error: call to undeclared function '__ldar64'` from `libmimalloc-sys2`. The previous workflow ran with `fail-fast` (the implicit default), so the Windows ARM64 job was always cancelled by an earlier failure and the regression went unnoticed. Now that the combined workflow uses `fail-fast: false`, the underlying compilation error is visible. Clang in MSVC-compat mode does not declare `__ldar64`/`__stlr64` (ARM64 load-acquire/store-release intrinsics) that mimalloc's `atomic.h` calls. Set `CC=clang` only on Linux/macOS/FreeBSD where it's needed for cross-compilation; let `cc-rs` pick MSVC on Windows.
- **`ref:` input on `taiki-e/checkout-action`** triggered `! Unexpected input(s) 'ref', valid inputs are ['']` warnings — the action doesn't accept any inputs and the value was silently ignored. The push event already checks out the release commit (release-plz tags that commit without rewriting `HEAD`), so the default checkout is what we want. Also drop the corresponding `ref:` from `taiki-e/upload-rust-binary-action` since the default archive name template doesn't use `$tag` and dry-run doesn't need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)