### PR TITLE
Lint all targets, reuse code_imports, and dedup target-kind/file-list logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run: |
           cargo test
-          cargo clippy -- -D warnings
+          cargo clippy --all-targets -- -D warnings
           cargo fmt --all -- --check
           cargo run .
 

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ fmt:
   taplo format
 
 lint:
-  cargo clippy
+  cargo clippy --all-targets
 
 snapshots:
   cargo insta test --accept

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -343,36 +343,35 @@ impl ShearDiagnostic {
     }
 
     pub fn unlinked_files(diagnostics: &[UnlinkedFile], package: &str) -> Self {
-        let paths: BTreeSet<_> = diagnostics.iter().map(|file| file.path.clone()).collect();
-        let help = if paths.len() == 1 {
-            "delete this file".to_owned()
-        } else {
-            "delete these files".to_owned()
-        };
-
-        Self {
-            kind: DiagnosticKind::UnlinkedFiles { package: package.to_owned(), paths },
-            source: None,
-            span: None,
-            related: Vec::new(),
-            help: Some(help),
-        }
+        let paths = diagnostics.iter().map(|file| file.path.clone()).collect();
+        Self::file_list(paths, |paths| DiagnosticKind::UnlinkedFiles {
+            package: package.to_owned(),
+            paths,
+        })
     }
 
     pub fn empty_files(diagnostics: &[EmptyFile], package: &str) -> Self {
-        let paths: BTreeSet<_> = diagnostics.iter().map(|file| file.path.clone()).collect();
-        let help = if paths.len() == 1 {
-            "delete this file".to_owned()
-        } else {
-            "delete these files".to_owned()
-        };
+        let paths = diagnostics.iter().map(|file| file.path.clone()).collect();
+        Self::file_list(paths, |paths| DiagnosticKind::EmptyFiles {
+            package: package.to_owned(),
+            paths,
+        })
+    }
 
+    /// Shared builder for the sourceless "delete file(s)" diagnostics
+    /// (`unlinked_files` / `empty_files`): both collect a `BTreeSet` of paths
+    /// and differ only in the `DiagnosticKind` they wrap it in.
+    fn file_list(
+        paths: BTreeSet<PathBuf>,
+        make_kind: impl FnOnce(BTreeSet<PathBuf>) -> DiagnosticKind,
+    ) -> Self {
+        let help = if paths.len() == 1 { "delete this file" } else { "delete these files" };
         Self {
-            kind: DiagnosticKind::EmptyFiles { package: package.to_owned(), paths },
+            kind: make_kind(paths),
             source: None,
             span: None,
             related: Vec::new(),
-            help: Some(help),
+            help: Some(help.to_owned()),
         }
     }
 
@@ -491,27 +490,9 @@ impl DiagnosticKind {
                 format!("misplaced optional dependency `{name}`")
             }
             Self::UnlinkedFiles { package, paths } => {
-                let count = paths.len();
-                let s = if count == 1 { "" } else { "s" };
-                let paths = paths
-                    .iter()
-                    .map(|path| path.display().to_string().replace('\\', "/"))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                format!("{count} unlinked file{s} in `{package}`\n{paths}")
+                Self::file_list_message("unlinked", package, paths)
             }
-            Self::EmptyFiles { package, paths } => {
-                let count = paths.len();
-                let s = if count == 1 { "" } else { "s" };
-                let paths = paths
-                    .iter()
-                    .map(|path| path.display().to_string().replace('\\', "/"))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                format!("{count} empty file{s} in `{package}`\n{paths}")
-            }
+            Self::EmptyFiles { package, paths } => Self::file_list_message("empty", package, paths),
             Self::UnknownIgnore { name } => format!("unknown ignore `{name}`"),
             Self::RedundantIgnore { name } => format!("redundant ignore `{name}`"),
             Self::RedundantIgnorePath { pattern } => {
@@ -538,6 +519,21 @@ impl DiagnosticKind {
                 )
             }
         }
+    }
+
+    /// Render the multi-line message shared by `UnlinkedFiles` / `EmptyFiles`:
+    /// a count line followed by one path per line, with backslashes normalised
+    /// to forward slashes.
+    fn file_list_message(label: &str, package: &str, paths: &BTreeSet<PathBuf>) -> String {
+        let count = paths.len();
+        let s = if count == 1 { "" } else { "s" };
+        let paths = paths
+            .iter()
+            .map(|path| path.display().to_string().replace('\\', "/"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!("{count} {label} file{s} in `{package}`\n{paths}")
     }
 
     pub const fn label(&self) -> Option<&'static str> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -85,6 +85,29 @@ impl fmt::Display for DepTable {
     }
 }
 
+/// Canonical Cargo label for a lib-like target kind (the string Cargo uses,
+/// e.g. `lib`, `rlib`, `proc-macro`). Returns `None` for non-lib kinds (`bin`,
+/// `test`, `bench`, `example`, custom build scripts), so the same call doubles
+/// as the "is this a lib-like target?" predicate via [`Option::is_some`].
+#[must_use]
+pub const fn lib_kind_label(kind: &TargetKind) -> Option<&'static str> {
+    match kind {
+        TargetKind::Lib => Some("lib"),
+        TargetKind::CDyLib => Some("cdylib"),
+        TargetKind::DyLib => Some("dylib"),
+        TargetKind::ProcMacro => Some("proc-macro"),
+        TargetKind::RLib => Some("rlib"),
+        TargetKind::StaticLib => Some("staticlib"),
+        TargetKind::Bin
+        | TargetKind::Bench
+        | TargetKind::Example
+        | TargetKind::Test
+        | TargetKind::CustomBuild
+        | TargetKind::Unknown(_)
+        | _ => None,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DepLocation {
     /// Top-level: `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`.

--- a/src/package_analyzer.rs
+++ b/src/package_analyzer.rs
@@ -13,7 +13,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     context::PackageContext,
-    manifest::{DepTable, FeatureRef},
+    manifest::{DepTable, FeatureRef, lib_kind_label},
     source_parser::ParsedSource,
 };
 
@@ -65,9 +65,12 @@ impl AnalysisResult {
         self.normal.union(&self.dev).chain(&self.build).cloned().collect()
     }
 
-    pub fn feature_imports(&self) -> FxHashSet<String> {
-        let code = self.code_imports();
-        self.features.keys().filter(|key| !code.contains(*key)).cloned().collect()
+    /// Imports referenced only from `[features]`, excluding any that already
+    /// appear in code. `code_imports` is taken as a parameter so callers that
+    /// already computed it (via [`code_imports`](Self::code_imports)) don't pay
+    /// to rebuild the union set.
+    pub fn feature_imports(&self, code_imports: &FxHashSet<String>) -> FxHashSet<String> {
+        self.features.keys().filter(|key| !code_imports.contains(*key)).cloned().collect()
     }
 }
 
@@ -155,17 +158,7 @@ impl<'a> PackageAnalyzer<'a> {
             // Lib-like targets only. Bin targets share source directories with the
             // package's lib target, so we can't tell which file's tests "belong" to
             // which target — recording for both would produce duplicate diagnostics.
-            let is_lib = matches!(
-                kind,
-                TargetKind::Lib
-                    | TargetKind::CDyLib
-                    | TargetKind::DyLib
-                    | TargetKind::ProcMacro
-                    | TargetKind::RLib
-                    | TargetKind::StaticLib
-            );
-
-            if is_lib {
+            if lib_kind_label(kind).is_some() {
                 let has_tests = matching_files.iter().any(|(_, parsed)| parsed.has_tests);
                 let has_doctests = matching_files.iter().any(|(_, parsed)| parsed.has_doctests);
 

--- a/src/package_processor.rs
+++ b/src/package_processor.rs
@@ -34,11 +34,9 @@ use anyhow::Result;
 use rustc_hash::FxHashSet;
 use toml::Spanned;
 
-use cargo_metadata::TargetKind;
-
 use crate::{
     context::{PackageContext, WorkspaceContext},
-    manifest::{DepLocation, FeatureRef},
+    manifest::{DepLocation, FeatureRef, lib_kind_label},
     package_analyzer::PackageAnalyzer,
 };
 
@@ -273,7 +271,7 @@ impl PackageProcessor {
         let used_imports = analyzer.analyze()?;
 
         let code_imports = used_imports.code_imports();
-        let feature_imports = used_imports.feature_imports();
+        let feature_imports = used_imports.feature_imports(&code_imports);
 
         let mut result = PackageAnalysis::default();
 
@@ -450,18 +448,9 @@ impl PackageProcessor {
         if self.check_test_targets {
             let is_workspace = ctx.workspace.packages.len() > 1;
             for info in &used_imports.target_test_info {
-                #[expect(
-                    clippy::wildcard_enum_match_arm,
-                    reason = "Only lib-like targets reach here"
-                )]
-                let kind_str = match &info.target_kind {
-                    TargetKind::CDyLib => "cdylib",
-                    TargetKind::DyLib => "dylib",
-                    TargetKind::ProcMacro => "proc-macro",
-                    TargetKind::RLib => "rlib",
-                    TargetKind::StaticLib => "staticlib",
-                    _ => "lib",
-                };
+                // Only lib-like targets populate `target_test_info`, so the
+                // fallback is unreachable in practice.
+                let kind_str = lib_kind_label(&info.target_kind).unwrap_or("lib");
 
                 if !info.test_enabled && info.has_tests {
                     result.test_disabled_with_tests.push(TestDisabledWithTests {

--- a/src/source_parser.rs
+++ b/src/source_parser.rs
@@ -1097,33 +1097,33 @@ mod tests {
 
     #[test]
     fn detects_normal_test() {
-        let source = r#"
+        let source = r"
             #[test]
             fn my_test() {}
-        "#;
+        ";
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
         assert!(parsed.has_tests);
     }
 
     #[test]
     fn detects_cfg_test_module() {
-        let source = r#"
+        let source = r"
             #[cfg(test)]
             mod tests {
                 fn my_test() {}
             }
-        "#;
+        ";
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
         assert!(parsed.has_tests);
     }
 
     #[test]
     fn detects_test_behind_non_test_cfg() {
-        let source = r#"
+        let source = r"
             #[test]
             #[cfg(any(coverage, coverage_nightly))]
             fn my_test() {}
-        "#;
+        ";
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
         assert!(parsed.has_tests);
     }


### PR DESCRIPTION
Implements three improvements identified in a codebase review.

## 1. CI now lints test/integration/example targets

`cargo clippy` (without `--all-targets`) only checks the default target — `#[cfg(test)]` modules, `tests/integration_tests.rs`, and examples were never linted by CI (`cargo clippy -- -D warnings`) or `just lint`. This let three `needless_raw_string_hashes` warnings live in `src/source_parser.rs` undetected.

- CI and `just lint` now run `cargo clippy --all-targets`.
- Fixed the three raw-string warnings the change surfaces.

## 2. Stop recomputing `code_imports()` per package

`AnalysisResult::feature_imports()` rebuilt the normal/dev/build import union (a fresh `FxHashSet<String>` cloning every import) even though `process_package` had just computed the identical set. It now takes the precomputed set as a parameter, eliminating one full union+clone allocation per package. Both call sites are already gated on `code_imports`, so behavior is unchanged.

## 4. Remove duplication

- **`manifest::lib_kind_label`** is now the single source of truth for lib-like target kinds. It replaces the duplicated `TargetKind` variant list in `package_analyzer` (the `is_lib` predicate) and the parallel string match in `package_processor` — which also lets us drop a `wildcard_enum_match_arm` `#[expect]` and the now-unused `TargetKind` import.
- **`ShearDiagnostic::file_list`** and **`DiagnosticKind::file_list_message`** collapse the near-identical `unlinked_files`/`empty_files` constructors and their `message()` arms, which differed only by one word.

All changes are behavior-preserving (item 3 from the review — per-package scans of the whole-workspace file map — was deferred pending a benchmark).

Verified with `just ready`: `typos`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full test suite (141 unit + 81 integration + doctests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
