### PR TITLE
chore: release v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1](https://github.com/Boshen/cargo-shear/compare/v1.13.0...v1.13.1) - 2026-06-06
+
+### <!-- 1 -->🐛 Bug Fixes
+- don't flag load-bearing workspace ignores as redundant ([#524](https://github.com/Boshen/cargo-shear/pull/524)) (by @Boshen)
+
+### <!-- 4 -->⚡ Performance
+- single preorder walk, track use-nesting instead of per-path ancestor scan (by @Boshen)
+- store crate-name imports as CompactString ([#525](https://github.com/Boshen/cargo-shear/pull/525)) (by @Boshen)
+
+### Contributors
+
+* @Boshen
+* @renovate[bot]
+
 ## [1.13.0](https://github.com/Boshen/cargo-shear/compare/v1.12.4...v1.13.0) - 2026-06-04
 
 ### <!-- 0 -->🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.13.0 -> 1.13.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.13.1](https://github.com/Boshen/cargo-shear/compare/v1.13.0...v1.13.1) - 2026-06-06

### <!-- 1 -->🐛 Bug Fixes
- don't flag load-bearing workspace ignores as redundant ([#524](https://github.com/Boshen/cargo-shear/pull/524)) (by @Boshen)

### <!-- 4 -->⚡ Performance
- single preorder walk, track use-nesting instead of per-path ancestor scan (by @Boshen)
- store crate-name imports as CompactString ([#525](https://github.com/Boshen/cargo-shear/pull/525)) (by @Boshen)

### Contributors

* @Boshen
* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).