### PR TITLE
perf: store crate-name imports as CompactString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "bpaf",
  "cargo_metadata",
  "cargo_toml",
+ "compact_str",
  "globset",
  "ignore",
  "insta",
@@ -138,6 +139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +176,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -700,6 +724,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +839,12 @@ dependencies = [
  "borsh",
  "serde_core",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ miette = { version = "7.6", default-features = false, features = [
   "fancy-no-backtrace",
 ] }
 owo-colors = "4.2.3"
+compact_str = "0.9.1"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/package_analyzer.rs
+++ b/src/package_analyzer.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use cargo_metadata::TargetKind;
+use compact_str::CompactString;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
@@ -39,16 +40,16 @@ pub struct TargetTestInfo {
 #[derive(Debug, Default)]
 pub struct AnalysisResult {
     /// Imports observed in normal targets (lib, bin, ...).
-    pub normal: FxHashSet<String>,
+    pub normal: FxHashSet<CompactString>,
 
     /// Imports observed in dev targets (test, bench, example).
-    pub dev: FxHashSet<String>,
+    pub dev: FxHashSet<CompactString>,
 
     /// Imports observed in build scripts.
-    pub build: FxHashSet<String>,
+    pub build: FxHashSet<CompactString>,
 
     /// Imports referenced from `[features]` entries, with the feature entries that name them.
-    pub features: FxHashMap<String, Vec<FeatureRef>>,
+    pub features: FxHashMap<CompactString, Vec<FeatureRef>>,
 
     /// Source files not reachable from any entry point (lib.rs, main.rs, ...).
     pub unlinked_files: FxHashSet<PathBuf>,
@@ -61,7 +62,7 @@ pub struct AnalysisResult {
 }
 
 impl AnalysisResult {
-    pub fn code_imports(&self) -> FxHashSet<String> {
+    pub fn code_imports(&self) -> FxHashSet<CompactString> {
         self.normal.union(&self.dev).chain(&self.build).cloned().collect()
     }
 
@@ -69,8 +70,11 @@ impl AnalysisResult {
     /// appear in code. `code_imports` is taken as a parameter so callers that
     /// already computed it (via [`code_imports`](Self::code_imports)) don't pay
     /// to rebuild the union set.
-    pub fn feature_imports(&self, code_imports: &FxHashSet<String>) -> FxHashSet<String> {
-        self.features.keys().filter(|key| !code_imports.contains(*key)).cloned().collect()
+    pub fn feature_imports(
+        &self,
+        code_imports: &FxHashSet<CompactString>,
+    ) -> FxHashSet<CompactString> {
+        self.features.keys().filter(|key| !code_imports.contains(key.as_str())).cloned().collect()
     }
 }
 
@@ -144,7 +148,7 @@ impl<'a> PackageAnalyzer<'a> {
                 })
                 .collect();
 
-            let imports: FxHashSet<String> = matching_files
+            let imports: FxHashSet<CompactString> = matching_files
                 .iter()
                 .flat_map(|(_, parsed)| parsed.imports.iter().cloned())
                 .collect();
@@ -241,13 +245,13 @@ impl<'a> PackageAnalyzer<'a> {
         for (feature, values) in &self.ctx.manifest.features {
             for value in values {
                 let (import, feature) = FeatureRef::parse(feature, value);
-                self.result.features.entry(import).or_default().push(feature);
+                self.result.features.entry(import.into()).or_default().push(feature);
             }
         }
 
         for (dep, details) in &self.ctx.manifest.dependencies {
             if details.get_ref().optional() {
-                let import = dep.get_ref().replace('-', "_");
+                let import = CompactString::from(dep.get_ref().replace('-', "_"));
                 let has_explicit = self.result.features.get(&import).is_some_and(|features| {
                     features.iter().any(|feature| matches!(feature, FeatureRef::Explicit { .. }))
                 });

--- a/src/source_parser.rs
+++ b/src/source_parser.rs
@@ -11,6 +11,7 @@ use std::{
     path::{Path as StdPath, PathBuf},
 };
 
+use compact_str::CompactString;
 use pulldown_cmark::{CodeBlockKind, Event, Parser, Tag, TagEnd};
 use ra_ap_syntax::{
     AstNode, AstToken, Edition, NodeOrToken, SourceFile, SyntaxKind, SyntaxNode, SyntaxToken,
@@ -27,7 +28,9 @@ use crate::util::read_to_string;
 #[derive(Debug, Default)]
 pub struct ParsedSource {
     /// External-crate names this file imports (deduplicated, normalised to import form).
-    pub imports: FxHashSet<String>,
+    /// `CompactString` inlines names up to 24 bytes, so most crate names avoid a heap
+    /// allocation entirely.
+    pub imports: FxHashSet<CompactString>,
 
     /// Files referenced by `mod`/`include!`/`#[path = "..."]`, used to compute reachability.
     pub paths: FxHashSet<PathBuf>,
@@ -657,7 +660,7 @@ impl SourceParser {
             return;
         }
 
-        self.result.imports.insert(clean.to_owned());
+        self.result.imports.insert(clean.into());
     }
 
     fn is_known_import(import: &str) -> bool {
@@ -707,7 +710,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".into()]));
         assert!(parsed.has_doctests);
     }
 
@@ -725,7 +728,7 @@ mod tests {
         ";
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["async_trait".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["async_trait".into()]));
         assert!(parsed.has_doctests);
     }
 
@@ -740,7 +743,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["serde_json".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["serde_json".into()]));
         assert!(parsed.has_doctests);
     }
 
@@ -755,7 +758,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".into()]));
         assert!(!parsed.has_doctests);
     }
 
@@ -770,7 +773,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".into()]));
         assert!(parsed.has_doctests);
     }
 
@@ -785,7 +788,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".into()]));
         assert!(parsed.has_doctests);
     }
 
@@ -800,7 +803,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".into()]));
         assert!(parsed.has_doctests);
     }
 
@@ -815,7 +818,7 @@ mod tests {
         "#;
 
         let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".to_owned()]));
+        assert_eq!(parsed.imports, FxHashSet::from_iter(["url".into()]));
         assert!(parsed.has_doctests);
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,7 +11,7 @@ use crate::{
 #[track_caller]
 fn test(source_text: &str) {
     let parsed = ParsedSource::from_str(source_text, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected, "{source_text}");
 }
 
@@ -180,7 +180,7 @@ fn multiple_imports_same_crate() {
         }
     ";
     let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -290,14 +290,14 @@ fn very_long_path() {
     let long_path = "foo::".repeat(100) + "bar";
     let source = format!("use {long_path};");
     let parsed = ParsedSource::from_str(&source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
 #[test]
 fn unicode_identifiers() {
     let parsed = ParsedSource::from_str("use foo::数据;", Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -320,7 +320,7 @@ fn raw_string_inside_macro() {
 #[test]
 fn glob_imports() {
     let parsed = ParsedSource::from_str("use foo::*;", Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -373,7 +373,7 @@ fn cargo_shear_with_package_filter() {
             locked: false,
             offline: false,
             frozen: false,
-            package: vec!["cargo-shear".to_owned()],
+            package: vec!["cargo-shear".into()],
             exclude: vec![],
             path: default_path().unwrap(),
             expand: false,
@@ -398,7 +398,7 @@ fn cargo_shear_with_exclude_filter() {
             offline: false,
             frozen: false,
             package: vec![],
-            exclude: vec!["some-package".to_owned()],
+            exclude: vec!["some-package".into()],
             path: default_path().unwrap(),
             expand: false,
             check_test_targets: false,
@@ -419,8 +419,8 @@ fn cargo_shear_options_creation() {
         locked: false,
         offline: false,
         frozen: false,
-        package: vec!["test1".to_owned(), "test2".to_owned()],
-        exclude: vec!["exclude1".to_owned()],
+        package: vec!["test1".into(), "test2".into()],
+        exclude: vec!["exclude1".into()],
         path: std::path::PathBuf::from("/tmp"),
         expand: true,
         check_test_targets: false,
@@ -464,7 +464,7 @@ fn mixed_valid_invalid_imports() {
         use foo::baz::qux;  // valid, same crate as first
     ";
     let parsed = ParsedSource::from_str(source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -479,7 +479,7 @@ fn test_no_deps(source_text: &str) {
 #[track_caller]
 fn test_multiple_deps(source_text: &str, expected_deps: &[&str]) {
     let parsed = ParsedSource::from_str(source_text, Path::new("lib.rs"));
-    let expected = expected_deps.iter().map(|s| (*s).to_owned()).collect::<FxHashSet<_>>();
+    let expected = expected_deps.iter().map(|s| (*s).into()).collect::<FxHashSet<_>>();
     assert_eq!(parsed.imports, expected, "Dependencies mismatch for: {source_text}");
 }
 
@@ -512,7 +512,7 @@ fn large_file_simulation() {
     }
 
     let parsed = ParsedSource::from_str(&source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -521,7 +521,7 @@ fn deeply_nested_paths() {
     let nested_path = (0..20).map(|i| format!("level{i}")).collect::<Vec<_>>().join("::");
     let source = format!("use foo::{nested_path};");
     let parsed = ParsedSource::from_str(&source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -752,7 +752,7 @@ fn many_small_imports() {
         writeln!(source, "use foo::item{i};").unwrap();
     }
     let parsed = ParsedSource::from_str(&source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -763,7 +763,7 @@ fn deeply_nested_modules() {
         writeln!(source, "mod level{i} {{ use foo::item{i}; }}").unwrap();
     }
     let parsed = ParsedSource::from_str(&source, Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into()]);
     assert_eq!(parsed.imports, expected);
 }
 
@@ -866,7 +866,7 @@ fn multiple_colon_patterns() {
     // Mixed valid and invalid patterns
     let parsed =
         ParsedSource::from_str("fn main() { foo::bar(); baz:::qux(); }", Path::new("lib.rs"));
-    let expected = FxHashSet::from_iter(["foo".to_owned(), "baz".to_owned()]);
+    let expected = FxHashSet::from_iter(["foo".into(), "baz".into()]);
     assert_eq!(parsed.imports, expected);
 }
 


### PR DESCRIPTION
## Summary

Crate names are short and repeat heavily across a workspace. Storing them in `compact_str::CompactString` inlines names up to 24 bytes, so typical names (`serde`, `tokio`, `anyhow`, ...) avoid a heap allocation.

The import-bearing sets switch from `String` to `CompactString`:
- `ParsedSource.imports`
- `AnalysisResult.{normal,dev,build}` and the `features` map keys
- `code_imports()` / `feature_imports()` return types

Lookups against these sets already went through `&str`, so `Borrow<str>` covers them — `package_processor.rs` needed zero changes.

## Measurements (oxc workspace)

Measured with a counting global allocator:

| Metric | `String` | `CompactString` | Δ |
|--------|----------|-----------------|---|
| Total allocation count | ~20,293,300 | ~20,249,100 | **−44,200 (−0.22%)** |
| Total bytes allocated | ~1,917.5 MB | ~1,917.1 MB | −0.4 MB (−0.02%) |
| Peak RSS | — | — | no measurable change |

This is an allocation-churn cleanup, not a memory win: total allocation is dominated by `ra_ap_syntax` syntax trees, and peak RSS is unchanged. The change has no measurable downside and removes the avoidable heap allocations on the hot import-collection path.