### PR TITLE
chore: release v1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.2](https://github.com/Boshen/cargo-shear/compare/v1.13.1...v1.13.2) - 2026-07-16
+
+### <!-- 1 -->🐛 Bug Fixes
+- detect serde attributes inside macros ([#543](https://github.com/Boshen/cargo-shear/pull/543)) (by @Boshen)
+
+### <!-- 3 -->📚 Documentation
+- add security policy ([#537](https://github.com/Boshen/cargo-shear/pull/537)) (by @Boshen)
+
+### <!-- 6 -->🧪 Testing
+- cover serde attributes forwarded through another attribute ([#546](https://github.com/Boshen/cargo-shear/pull/546)) (by @Boshen)
+
+### Contributors
+
+* @renovate[bot]
+* @Boshen
+
 ## [1.13.1](https://github.com/Boshen/cargo-shear/compare/v1.13.0...v1.13.1) - 2026-06-06
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.13.1"
+version = "1.13.2"
 edition = "2024"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.13.1 -> 1.13.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.13.2](https://github.com/Boshen/cargo-shear/compare/v1.13.1...v1.13.2) - 2026-07-16

### <!-- 1 -->🐛 Bug Fixes
- detect serde attributes inside macros ([#543](https://github.com/Boshen/cargo-shear/pull/543)) (by @Boshen)

### <!-- 3 -->📚 Documentation
- add security policy ([#537](https://github.com/Boshen/cargo-shear/pull/537)) (by @Boshen)

### <!-- 6 -->🧪 Testing
- cover serde attributes forwarded through another attribute ([#546](https://github.com/Boshen/cargo-shear/pull/546)) (by @Boshen)

### Contributors

* @renovate[bot]
* @Boshen
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).