### PR TITLE
docs: add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Please refer to https://oxc.rs/docs/contribute/security.html for our established security practices.
+
+## Security contact information
+
+To report a security vulnerability, please use the [Tidelift security contact](https://tidelift.com/security).
+Tidelift will coordinate the fix and disclosure.


### PR DESCRIPTION
Add `.github/SECURITY.md` pointing to the oxc security practices and the Tidelift security contact for reporting vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)