### PR TITLE
test: cover serde attributes forwarded through another attribute

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -130,6 +130,16 @@ fn serde_attributes_inside_macro() {
     test("m! { #[serde(remote = \"foo\")] struct Bar; }");
 }
 
+// A `serde(...)` forwarded through another attribute is reached only by the token
+// scan: the `Attr` path is `confik`, so the path check in `collect_meta_imports`
+// never fires. Gating that scan on the attribute path would silently break this.
+// https://docs.rs/confik/0.15.12/confik/#forwarding-attributes
+#[test]
+fn serde_attributes_forwarded_by_another_attribute() {
+    test("struct Foo { #[confik(forward(serde(with = \"foo\")))] f: () }");
+    test("#[confik(forward(serde(crate = \"foo\")))] struct Foo { f: () }");
+}
+
 #[test]
 fn test_lib() {
     let shear = CargoShear::new(


### PR DESCRIPTION
Adds a regression test for a `serde` attribute forwarded through another attribute, as [confik](https://docs.rs/confik/0.15.12/confik/#forwarding-attributes) does:

```rust
struct Foo {
    #[confik(forward(serde(with = "humantime_serde")))]
    timeout: Duration,
}
```

This is the shape reported in #542. It is not a macro body — confik is a derive macro, so the attribute is a plain `Attr` node. It failed because `collect_meta_imports` only calls `collect_serde_attribute` when the attribute's own path is literally `serde`, and here it is `confik`.

#543 already fixes it: the token scan added in `collect_token_tree` runs on every attribute's token tree and matches on a `serde` ident anywhere in the stream, so the nested `serde(...)` is picked up regardless of the outer path. The existing `serde_attributes_inside_macro` test does not cover this path — it would keep passing if the scan were ever narrowed to the attribute path or scoped to macro bodies, silently regressing confik. This test pins that behaviour: it fails with the #543 hunk reverted (`left: {}, right: {"foo"}`).
