### PR TITLE
chore: release v1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.3](https://github.com/Boshen/cargo-shear/compare/v1.13.2...v1.13.3) - 2026-07-24
+
+### <!-- 3 -->📚 Documentation
+- declare MSRV ([#551](https://github.com/Boshen/cargo-shear/pull/551)) (by @Boshen)
+
+### <!-- 4 -->⚡ Performance
+- avoid duplicate path import probes ([#553](https://github.com/Boshen/cargo-shear/pull/553)) (by @Boshen)
+
+### Contributors
+
+* @Boshen
+* @renovate[bot]
+
 ## [1.13.2](https://github.com/Boshen/cargo-shear/compare/v1.13.1...v1.13.2) - 2026-07-16
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shear"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "anyhow",
  "bpaf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shear"
-version = "1.13.2"
+version = "1.13.3"
 edition = "2024"
 rust-version = "1.95"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"


### PR DESCRIPTION



## 🤖 New release

* `cargo-shear`: 1.13.2 -> 1.13.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.13.3](https://github.com/Boshen/cargo-shear/compare/v1.13.2...v1.13.3) - 2026-07-24

### <!-- 3 -->📚 Documentation
- declare MSRV ([#551](https://github.com/Boshen/cargo-shear/pull/551)) (by @Boshen)

### <!-- 4 -->⚡ Performance
- avoid duplicate path import probes ([#553](https://github.com/Boshen/cargo-shear/pull/553)) (by @Boshen)

### Contributors

* @Boshen
* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).