### PR TITLE
docs: declare MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargo-shear"
 version = "1.13.2"
 edition = "2024"
+rust-version = "1.95"
 description = "Detect and fix unused/misplaced dependencies from Cargo.toml"
 authors = ["Boshen <boshenc@gmail.com>"]
 repository = "https://github.com/Boshen/cargo-shear"


### PR DESCRIPTION
Declare Rust 1.95 as the minimum supported Rust version in package metadata.

Closes #550.